### PR TITLE
Added CICE restart logic and compiler files for met_ppi ibx queue

### DIFF
--- a/apps/common/modified_src/cice5.1.2/bld/Macros.Linux.MET_PPI_ibx
+++ b/apps/common/modified_src/cice5.1.2/bld/Macros.Linux.MET_PPI_ibx
@@ -1,0 +1,68 @@
+#==============================================================================
+# Makefile macros for MET PPI
+#==============================================================================
+
+INCLDIR    := -I$(MCT_INCDIR)
+SLIBS      := -L$(MCT_LIBDIR) -lmct -lmpeu
+ULIBS      := 
+CPP        := /usr/bin/cpp
+CPPFLAGS   := -P -traditional
+CPPDEFS    := -DLINUX
+CFLAGS     := -c -O2
+ifeq ($(COMMDIR), mpi)
+   FC         := mpif90
+else
+   FC         := ifort
+endif
+FIXEDFLAGS := -132
+FREEFLAGS  := 
+# Should use this together with ROMS? 
+FFLAGS     :=  -ip -O3 -ftz -xCORE-AVX2 -shared-intel -r8 -convert big_endian -IPF_fp_relaxed -assume noold_maxminloc -mcmodel large
+MOD_SUFFIX := mod
+LD         := $(FC)
+LDFLAGS    := $(FFLAGS) -v
+
+    CPPDEFS :=  $(CPPDEFS) -DNXGLOB=$(NXGLOB) -DNYGLOB=$(NYGLOB) \
+                -DBLCKX=$(BLCKX) -DBLCKY=$(BLCKY) -DMXBLCKS=$(MXBLCKS) \
+                -DNICELYR=$(NICELYR) -DNSNWLYR=$(NSNWLYR) -DNICECAT=$(NICECAT) \
+                -DTRAGE=$(TRAGE) -DTRFY=$(TRFY) -DTRLVL=$(TRLVL) -DTRPND=$(TRPND) \
+                -DTRBRI=$(TRBRI) -DNTRAERO=$(NTRAERO) -DNBGCLYR=$(NBGCLYR) \
+                -DTRBGCS=$(TRBGCS) -DNUMIN=$(NUMIN) -DNUMAX=$(NUMAX)\
+	        -DROMSCOUPLED
+#   CPPDEFS :=  $(CPPDEFS) -DAOMIP
+
+ifeq ($(DITTO), yes)
+   CPPDEFS :=  $(CPPDEFS) -DREPRODUCIBLE
+endif
+ifeq ($(BARRIERS), yes)
+   CPPDEFS :=  $(CPPDEFS) -Dgather_scatter_barrier
+endif
+
+ifeq ($(IO_TYPE), netcdf)
+   CPPDEFS :=  $(CPPDEFS) -Dncdf
+   INCLDIR := $(INCLDIR) -I/modules/xenial/NETCDF/4.6.0intel18/include
+   SLIBS   := $(SLIBS) -L/modules/xenial/NETCDF/4.6.0intel18/lib -lnetcdff -L/modules/xenial/hdf5/1.10.1/lib -lnetcdf
+endif
+
+ifeq ($(compile_threaded), true) 
+   LDFLAGS += -openmp 
+   CFLAGS += -openmp 
+   FFLAGS += -openmp 
+endif
+
+
+### if using parallel I/O, load all 3 libraries.  PIO must be first! # Not
+#### tested on vilje
+ifeq ($(IO_TYPE), pio)
+#   INCLDIR := $(INCLDIR) -I/usr/projects/climate/SHARED_CLIMATE/software/conejo/intel_openmpi/pio-1.4.0
+#   SLIBS   := $(SLIBS) -L/usr/projects/climate/SHARED_CLIMATE/software/conejo/intel_openmpi/pio-1.4.0 -lpio
+
+#   INCLDIR := $(INCLDIR) -I/usr/projects/climate/SHARED_CLIMATE/software/conejo/intel_openmpi/parallel-netcdf-1.2.0/include
+#   SLIBS   := $(SLIBS) -L/usr/projects/climate/SHARED_CLIMATE/software/conejo/intel_openmpi/parallel-netcdf-1.2.0/lib -lpnetcdf
+
+#   CPPDEFS :=  $(CPPDEFS) -Dncdf
+#   INCLDIR := $(INCLDIR) -I/usr/projects/climate/SHARED_CLIMATE/software/conejo/intel_openmpi/netcdf-3.6.3/include
+   SLIBS   := $(SLIBS) -L/usr/projects/climate/SHARED_CLIMATE/software/conejo/intel_openmpi/netcdf-3.6.3/lib -lnetcdf
+
+endif
+

--- a/apps/common/modified_src/roms-trunk/Linux-ifort.mk_met_ppi_ibx
+++ b/apps/common/modified_src/roms-trunk/Linux-ifort.mk_met_ppi_ibx
@@ -1,0 +1,179 @@
+# svn $Id: Linux-ifort.mk 1411 2011-05-02 23:02:13Z kate $
+#::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+# Copyright (c) 2002-2011 The ROMS/TOMS Group                           :::
+#   Licensed under a MIT/X style license                                :::
+#   See License_ROMS.txt                                                :::
+#::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+#
+# Include file for Intel IFORT (version 10.1) compiler on Linux
+# -------------------------------------------------------------------------
+#
+# ARPACK_LIBDIR  ARPACK libary directory
+# FC             Name of the fortran compiler to use
+# FFLAGS         Flags to the fortran compiler
+# CPP            Name of the C-preprocessor
+# CPPFLAGS       Flags to the C-preprocessor
+# CC             Name of the C compiler
+# CFLAGS         Flags to the C compiler
+# CXX            Name of the C++ compiler
+# CXXFLAGS       Flags to the C++ compiler
+# CLEAN          Name of cleaning executable after C-preprocessing
+# NETCDF_INCDIR  NetCDF include directory
+# NETCDF_LIBDIR  NetCDF libary directory
+# LD             Program to load the objects into an executable
+# LDFLAGS        Flags to the loader
+# RANLIB         Name of ranlib command
+# MDEPFLAGS      Flags for sfmakedepend  (-s if you keep .f files)
+#
+# First the defaults
+#
+               FC := /modules/xenial/compiler/parallel_studio/2018/compilers_and_libraries/linux/bin/intel64/ifort
+           FFLAGS := -O3 -ftz -xCORE-AVX2 -shared-intel -r8 -convert big_endian -IPF_fp_relaxed -assume noold_maxminloc -mcmodel=large
+              CPP := /usr/bin/cpp
+         CPPFLAGS := -P -traditional
+               CC := /modules/xenial/compiler/parallel_studio/2018/compilers_and_libraries/linux/bin/intel64/icc
+              CXX := /modules/xenial/compiler/parallel_studio/2018/compilers_and_libraries/linux/bin/intel64/icpc
+           CFLAGS :=
+         CXXFLAGS :=
+          LDFLAGS :=
+               AR := ar
+          ARFLAGS := r
+            MKDIR := mkdir -p
+               RM := rm -f
+           RANLIB := ranlib
+             PERL := perl
+             TEST := test
+
+        MDEPFLAGS := --cpp --fext=f90 --file=- --objdir=$(SCRATCH_DIR)
+
+#
+# Library locations, can be overridden by environment variables.
+#
+
+ifdef USE_NETCDF4
+    NETCDF_INCDIR ?= /modules/xenial/NETCDF/4.5.0intel18/include
+             LIBS := -L/modules/xenial/NETCDF/4.5.0intel18/lib -lnetcdff -L/modules/xenial/hdf5/1.10.1intel18/lib -lnetcdf
+else
+    NETCDF_INCDIR ?= /modules/xenial/NETCDF/4.5.0intel18/include
+             LIBS := -L/modules/xenial/NETCDF/4.5.0intel18/lib -lnetcdff -L/modules/xenial/hdf5/1.10.1intel18/lib -lnetcdf
+endif
+
+ifdef USE_ARPACK
+ ifdef USE_MPI
+   PARPACK_LIBDIR ?= /opt/intelsoft/PARPACK
+             LIBS += -L$(PARPACK_LIBDIR) -lparpack
+ endif
+    ARPACK_LIBDIR ?= /opt/intelsoft/PARPACK
+             LIBS += -L$(ARPACK_LIBDIR) -larpack
+endif
+
+ifdef USE_MPI
+         CPPFLAGS += -DMPI
+ ifdef USE_MPIF90
+               FC := mpif90
+ else
+             LIBS += -L/modules/xenial/OPENMPI/3.0.0intel18/lib -lmpi_mpifh -lmpi
+           FFLAGS += -I/modules/xenial/OPENMPI/3.0.0intel18/include 
+ endif
+endif
+
+ifdef USE_OpenMP
+         CPPFLAGS += -D_OPENMP
+           FFLAGS += -openmp
+endif
+
+ifdef USE_DEBUG
+           FFLAGS += -g -check bounds -traceback
+#           FFLAGS += -g -check uninit -ftrapuv -traceback
+           CFLAGS += -g
+         CXXFLAGS += -g
+else
+#           FFLAGS += -ip -O3 
+           FFLAGS += -ip -O3
+           CFLAGS += -O3
+         CXXFLAGS += -O3
+endif
+
+ifdef USE_MCT
+       MCT_INCDIR ?= $(MY_ROMS_SRC)/../MCT/include
+       MCT_LIBDIR ?= $(MY_ROMS_SRC)/../MCT/lib
+           FFLAGS += -I$(MCT_INCDIR)
+             LIBS += -L$(MCT_LIBDIR) -lmct -lmpeu
+endif
+
+ifdef USE_CICE
+       CICE_INCDIR := $(MY_ROMS_SRC)/../${ROMS_APPLICATION}/cice/rundir/compile
+       CICE_LIBDIR := $(MY_ROMS_SRC)/../${ROMS_APPLICATION}/cice/rundir/compile
+           FFLAGS += -I$(CICE_INCDIR)
+             LIBS += -L$(CICE_LIBDIR) -lcice
+endif
+
+ifdef USE_ESMF
+      ESMF_SUBDIR := $(ESMF_OS).$(ESMF_COMPILER).$(ESMF_ABI).$(ESMF_COMM).$(ESMF_SITE)
+      ESMF_MK_DIR ?= $(ESMF_DIR)/lib/lib$(ESMF_BOPT)/$(ESMF_SUBDIR)
+                     include $(ESMF_MK_DIR)/esmf.mk
+           FFLAGS += $(ESMF_F90COMPILEPATHS)
+             LIBS += $(ESMF_F90LINKPATHS) -lesmf -lC
+endif
+
+ifdef USE_CXX
+             LIBS += -lstdc++
+endif
+
+       clean_list += ifc* work.pc*
+
+#
+# Use full path of compiler.
+#
+               FC := $(shell which ${FC})
+               LD := $(FC)
+
+#
+# Set free form format in source files to allow long string for
+# local directory and compilation flags inside the code.
+#
+
+$(SCRATCH_DIR)/mod_ncparam.o: FFLAGS += -free
+$(SCRATCH_DIR)/mod_strings.o: FFLAGS += -free
+$(SCRATCH_DIR)/analytical.o: FFLAGS += -free
+$(SCRATCH_DIR)/biology.o: FFLAGS += -free
+ifdef USE_ADJOINT
+$(SCRATCH_DIR)/ad_biology.o: FFLAGS += -free
+endif
+ifdef USE_REPRESENTER
+$(SCRATCH_DIR)/rp_biology.o: FFLAGS += -free
+endif
+ifdef USE_TANGENT
+$(SCRATCH_DIR)/tl_biology.o: FFLAGS += -free
+endif
+
+#
+# Supress free format in SWAN source files since there are comments
+# beyond column 72.
+#
+
+ifdef USE_SWAN
+
+$(SCRATCH_DIR)/ocpcre.o: FFLAGS += -nofree
+$(SCRATCH_DIR)/ocpids.o: FFLAGS += -nofree
+$(SCRATCH_DIR)/ocpmix.o: FFLAGS += -nofree
+$(SCRATCH_DIR)/swancom1.o: FFLAGS += -nofree
+$(SCRATCH_DIR)/swancom2.o: FFLAGS += -nofree
+$(SCRATCH_DIR)/swancom3.o: FFLAGS += -nofree
+$(SCRATCH_DIR)/swancom4.o: FFLAGS += -nofree
+$(SCRATCH_DIR)/swancom5.o: FFLAGS += -nofree
+$(SCRATCH_DIR)/swanmain.o: FFLAGS += -nofree
+$(SCRATCH_DIR)/swanout1.o: FFLAGS += -nofree
+$(SCRATCH_DIR)/swanout2.o: FFLAGS += -nofree
+$(SCRATCH_DIR)/swanparll.o: FFLAGS += -nofree
+$(SCRATCH_DIR)/swanpre1.o: FFLAGS += -nofree
+$(SCRATCH_DIR)/swanpre2.o: FFLAGS += -nofree
+$(SCRATCH_DIR)/swanser.o: FFLAGS += -nofree
+$(SCRATCH_DIR)/swmod1.o: FFLAGS += -nofree
+$(SCRATCH_DIR)/swmod2.o: FFLAGS += -nofree
+$(SCRATCH_DIR)/m_constants.o: FFLAGS += -free
+$(SCRATCH_DIR)/m_fileio.o: FFLAGS += -free
+$(SCRATCH_DIR)/mod_xnl4v5.o: FFLAGS += -free
+$(SCRATCH_DIR)/serv_xnl4v5.o: FFLAGS += -free
+
+endif

--- a/apps/common/python/ModelRun.py
+++ b/apps/common/python/ModelRun.py
@@ -2,7 +2,7 @@ import os
 import netCDF4
 import Constants
 from GlobalParams import *
-from datetime import datetime
+from datetime import datetime, timedelta
 import bisect
 import sys
 
@@ -51,6 +51,9 @@ class ModelRun(object):
         if (self._params.RESTART == True):
             print "Model is restarting from previuos solution..."
             self._cycle_rst_ini()
+
+            if self._params.CICECPU > 0:
+                self._verify_cice_rst_file()
 
     def postprocess(self):
         """
@@ -119,7 +122,13 @@ class ModelRun(object):
                 exit(1)
             else:
 #                os.environ["MPI_BUFS_PER_PROC"] = str(128)
-                result = os.system("/modules/xenial/OPENMPI/3.0.0/bin/mpirun  --mca btl openib,self -bind-to core "+executable+" "+infile)
+                #result = os.system("/modules/centos7/OPENMPI/4.0.0-intel2018/bin/mpiexec --mca mtl psm2 " + executable + " " + infile)
+                result = os.system("/modules/xenial/OPENMPI/3.0.0intel18/bin/mpiexec  --mca btl openib,self -bind-to core "+executable+" "+infile)
+                #result = os.system("/modules/xenial/OPENMPI/3.0.0intel18/bin/mpirun  --mca btl openib,self -bind-to core "+executable+" "+infile)
+                #result = os.system("/modules/xenial/OPENMPI/3.0.0/bin/mpirun  --mca btl tcp,self "+executable+" "+infile)
+                #runcmd="/modules/xenial/OPENMPI/3.0.0intel18/bin/mpirun -np "+str(ncpus)+" "+executable+" "+infile
+                #print runcmd
+                #result = os.system(runcmd)
                 if result != 0: os.system('cat cice_stderr')
         else:
             print "error here!"
@@ -298,6 +307,55 @@ class ModelRun(object):
                 print "Restartfile not found!! Will exit"
                 exit(1)
 
+    def _verify_cice_rst_file(self):
+        """Function checking if the specified model start time is found in the
+        CICE restart file located in cice restart pointer file, if not, it checks
+        if model start time is found in any other restart files in the restart
+        directory. All restart files are assumed to contain only one time and
+        if the model start time is not found, an IOError is raised."""
+
+        def date_in_cice_rst(date, filename, time_name="time"):
+            """Function checking for match between <date> and time in cice rst file."""
+            rst_data = netCDF4.Dataset(filename, "r")
+            file_date = datetime(date.year,1,1) + timedelta(seconds=float(rst_data.time))
+            print(filename, date, file_date)
+            return True if date == file_date else False
+
+        # open CICE restart pointer file and read filename
+        rst_dir = os.path.join(self._params.CICERUNDIR, "restart")
+        rst_pointer_file = os.path.join(rst_dir, "ice.restart_file")
+
+        with open(rst_pointer_file, "r") as rst_fp:
+            rst_file = rst_fp.read().strip()
+
+        # if model start date found in "default" CICE restart file
+        if date_in_cice_rst(self._params.START_DATE, rst_file):
+            print("Model start time matches CICE rst time in {}".format(rst_file))
+            return
+
+        # if not, search through all other restart files in the restart directory
+        else:
+            for element in os.listdir(rst_dir):
+                if element.endswith(".nc"):
+                    nc_abspath = os.path.join(rst_dir, element)
+
+                    if date_in_cice_rst(self._params.START_DATE, nc_abspath):
+                        with open(rst_pointer_file, "w") as rst_fp:
+                            rst_fp.write(nc_abspath)
+
+                        istep = netCDF4.Dataset(nc_abspath, "r").istep1
+                        cice_start_step = (self._params.START_DATE-datetime(self._params.START_DATE.year,01,01,00)).total_seconds()/self._params.CICEDELTAT
+
+                        for kv in self._params.CICEKEYWORDLIST:
+                            if kv[0] == "CICENPT":
+                                kv[1] = str(int((self._params.FCLEN/self._params.CICEDELTAT)-(istep - cice_start_step)))
+
+                        print("Found matching start time in {}, wrote to {}".format(
+                              nc_abspath, rst_pointer_file))
+                        return
+
+        raise IOError("No CICE restart file matching start date {}!".format(self._params.START_DATE))
+
     def _check_starttime(self):
         try:
             roms_ini = netCDF4.num2date(netCDF4.Dataset(self._params.RUNPATH+"/ocean_ini.nc").variables['ocean_time'][:],
@@ -309,6 +367,7 @@ class ModelRun(object):
             f = open(self._params.CICERUNDIR+'/restart/ice.restart_file', 'r')
             cice_restartfile = f.readline().strip()
             cice_rst_day = netCDF4.Dataset(cice_restartfile).mday
+            print("Params.NRREC = {}".format(self._params.NRREC))
             if (cice_rst_day == roms_ini[self._params.NRREC].day) :
                 # Dates seem ok
                 pass


### PR DESCRIPTION
The compiler files are currently simply copies of the already existing met_ppi compiler files. Will add simialr ones for Omnipath queue soon.

The ModelRun class has been updated to handle restart for CICE by looking in the cice/rundir/restart directory for a restart file corresponding with the specified model start time. If a file is found, its name is written to the pointer file ice.restart.