### PR TITLE
Support for ibx and opath run on met_ppi and added some documentation

### DIFF
--- a/apps/common/python/Constants.py
+++ b/apps/common/python/Constants.py
@@ -12,10 +12,11 @@ MET32=1
 VILJE=2
 BYVIND=3
 ALVIN=4
-MET_PPI=5
-ELVIS=6
-NEBULA=7
-STRATUS=8
+ELVIS=5
+NEBULA=6
+STRATUS=7
+MET_PPI_IBX=8
+MET_PPI_OPATH=9
 ########################################################################
 NC=0
 FELT=1


### PR DESCRIPTION
Added a distinction between the ibx and omnipath architecture on the PPI in the functions `ModelRun._run()` and `ModelRun._execute_roms_mpi()`. The corresponding distinction is made in `Constants.py`. Now `ModelRun.run_roms()` should be called with `architecture=Constants.MET_PPI_IBX` or `architecture=Constants.MET_PPI_OPATH` if you're running METROMS on the PPI. The run command for omnipath is only partially tested so far and thus might not be optimal (but should work). Might be updated in the future.

Also added some docstrings for various functions in `ModelRun.py`.