### PR TITLE
Kept Constants.MET_PPI and fixed back compat issue

### DIFF
--- a/apps/common/python/Constants.py
+++ b/apps/common/python/Constants.py
@@ -12,11 +12,12 @@ MET32=1
 VILJE=2
 BYVIND=3
 ALVIN=4
-ELVIS=5
-NEBULA=6
-STRATUS=7
-MET_PPI_IBX=8
-MET_PPI_OPATH=9
+MET_PPI=5
+ELVIS=6
+NEBULA=7
+STRATUS=8
+MET_PPI_IBX=9
+MET_PPI_OPATH=10
 ########################################################################
 NC=0
 FELT=1

--- a/apps/common/python/ModelRun.py
+++ b/apps/common/python/ModelRun.py
@@ -274,8 +274,16 @@ class ModelRun(object):
             architecture (int) : What architecture to run METROMS on
                                  (choose an option from the Contants module)
         """
+        # if statement for backwards compatibility (remove in the future)
+        # ---------------------------------------------------------------------------------------------------
+        if architecture == Constants.MET_PPI:
+            print("\nWarning: {0}={1} is deprecated! Use {0}={2} or {0}={3} instead. Defaulting to {2}.".format(
+                  "architecture", "Constants.MET_PPI", "Constants.MET_PPI_IBX", "Constants.MET_PPI_OPATH"))
+            architecture = Constants.MET_PPI_IBX
+        # ---------------------------------------------------------------------------------------------------
+
         # Run the ROMS model:
-        if architecture==Constants.MET64 :
+        if architecture==Constants.MET64:
             if runoption==Constants.MPI:
                 self._execute_roms_mpi((int(self._params.XCPU)*int(self._params.YCPU))+
                                        int(self._params.CICECPU),


### PR DESCRIPTION
Introduced an if-statement in `ModelRun._run()` to ensure backwards compatibility (that was disturbed in the previous commit) by still allowing users to pass `architecture=Constants.MET_PPI` to `ModelRun.run_roms()`. Now a warning is shown and it defaults to `Constants.MET_PPI_IBX`. This if-statement may be removed in the future when we decide it's safe to do so.