### PR TITLE
Added new opath netcdf modules to CICE compiler file

### DIFF
--- a/apps/common/modified_src/cice5.1.2/bld/Macros.Linux.MET_PPI_opath
+++ b/apps/common/modified_src/cice5.1.2/bld/Macros.Linux.MET_PPI_opath
@@ -41,7 +41,7 @@ endif
 ifeq ($(IO_TYPE), netcdf)
    CPPDEFS :=  $(CPPDEFS) -Dncdf
    INCLDIR := $(INCLDIR) -I/modules/centos7/netcdf/4.6.2-intel2018/include
-   SLIBS   :=  $(SLIBS) -L/modules/centos7/netcdf/4.6.2-intel2018/lib -lnetcdff -L/modules/centos7//netcdf/4.6.2-intel2018/lib -L/modules/centos7/hdf5/1.10.4/lib -L/modules/centos7/compiler/parallel_studio/2018/compilers_and_libraries/linux/lib -lnetcdf -lnetcdf
+   SLIBS   :=  $(SLIBS) -L/modules/centos7/netcdf/4.7.0-intel2018/lib -lnetcdff -L/modules/centos7/netcdf/4.7.0-intel2018/lib -L/modules/centos7/hdf5/1.10.5-intel2018/lib -L/modules/centos7/compiler/parallel_studio/2018/compilers_and_libraries/linux/lib -lnetcdf -lnetcdf -lhdf5_hl -lhdf5 -lsz -lz -lcurl -lm
 endif
 
 ifeq ($(compile_threaded), true) 

--- a/apps/common/modified_src/cice5.1.2/bld/Macros.Linux.MET_PPI_opath
+++ b/apps/common/modified_src/cice5.1.2/bld/Macros.Linux.MET_PPI_opath
@@ -40,7 +40,7 @@ endif
 
 ifeq ($(IO_TYPE), netcdf)
    CPPDEFS :=  $(CPPDEFS) -Dncdf
-   INCLDIR := $(INCLDIR) -I/modules/centos7/netcdf/4.6.2-intel2018/include
+   INCLDIR := $(INCLDIR) -I/modules/centos7/netcdf/4.7.0-intel2018/include
    SLIBS   :=  $(SLIBS) -L/modules/centos7/netcdf/4.7.0-intel2018/lib -lnetcdff -L/modules/centos7/netcdf/4.7.0-intel2018/lib -L/modules/centos7/hdf5/1.10.5-intel2018/lib -L/modules/centos7/compiler/parallel_studio/2018/compilers_and_libraries/linux/lib -lnetcdf -lnetcdf -lhdf5_hl -lhdf5 -lsz -lz -lcurl -lm
 endif
 


### PR DESCRIPTION
See title. This handling of netcdf modules for CICE should be generalized in the same way as done for ROMS, i.e. using call to nc-config command to automatically fill in include and lib directory paths based on what module was loaded by the call to "source ./modules.sh". I could not make this work at this time, but will look at it some time in the future.