### PR TITLE
Added support for hourly restart drops in CICE

### DIFF
--- a/apps/common/modified_src/cice5.1.2/source/ice_calendar.F90
+++ b/apps/common/modified_src/cice5.1.2/source/ice_calendar.F90
@@ -287,6 +287,9 @@
         case ("d", "D")
           if (new_day   .and. mod(elapsed_days, dumpfreq_n)==0) &
                 write_restart = 1
+        case ("h", "H")
+          if (new_hour   .and. mod(elapsed_hours, dumpfreq_n)==0) &
+                write_restart = 1
         end select
 
         if (force_restart_now) write_restart = 1


### PR DESCRIPTION
Adding a case statement in ice_calendar.f90 to handle the following settings in ice_in (dumpfreq_n can be any integer):
  , dumpfreq       = 'h'
  , dumpfreq_n     = 1