### PR TITLE
fixed issue with compiling certain apps on fram

### DIFF
--- a/apps/build_mct.sh
+++ b/apps/build_mct.sh
@@ -19,8 +19,11 @@ cd $MCT_DIR
 
 if [ ${METROMS_MYHOST} == "metlocal" ] || [ "${METROMS_MYHOST}" == "met_ppi" ]; then
     FORT=mpif90
-elif [ ${METROMS_MYHOST} == "vilje" ] || [ ${METROMS_MYHOST} == "fram" ]; then
+elif [ ${METROMS_MYHOST} == "vilje" ] ; then
     FORT=ifort
+elif [ ${METROMS_MYHOST} == "fram" ] ; then
+    FORT=ifort
+    export I_MPI_F90=ifort
 else
     echo " Computer not defined set environment variable METROMS_MYHOST= metlocal, vilje .."
     exit

--- a/apps/build_roms.sh
+++ b/apps/build_roms.sh
@@ -68,8 +68,11 @@ export USE_CICE=on
 
 if [ "${METROMS_MYHOST}" == "metlocal" ]; then
     export FORT=gfortran
-elif [ "${METROMS_MYHOST}" == "vilje" ] || [ "${METROMS_MYHOST}" == "fram" ] ; then
+elif [ "${METROMS_MYHOST}" == "vilje" ] ; then
     export FORT=ifort
+elif [ "${METROMS_MYHOST}" == "fram" ] ; then
+    export FORT=ifort
+    export I_MPI_F90=ifort
 elif [ "${METROMS_MYHOST}" == "met_ppi" ] ; then
     export FORT=ifort
     export USE_MPI=on

--- a/apps/build_roms_standalone.sh
+++ b/apps/build_roms_standalone.sh
@@ -70,8 +70,11 @@ export which_MPI=mpich2        # compile with MPICH2 library
 
 if [ "${METROMS_MYHOST}" == "metlocal" ]; then
     export FORT=gfortran
-elif [ "${METROMS_MYHOST}" == "vilje" ] || [ "${METROMS_MYHOST}" == "fram" ] ; then
+elif [ "${METROMS_MYHOST}" == "vilje" ] ; then
     export FORT=ifort
+elif [ "${METROMS_MYHOST}" == "fram" ] ; then
+    export FORT=ifort
+    export I_MPI_F90=ifort
 elif [ "${METROMS_MYHOST}" == "nebula" ] || [ "${METROMS_MYHOST}" == "stratus" ]; then
     export FORT=ifort
     export USE_MPIF90=on

--- a/apps/common/modified_src/cice5.1.2/comp_ice
+++ b/apps/common/modified_src/cice5.1.2/comp_ice
@@ -23,6 +23,7 @@ elif [ "$METROMS_MYHOST" == "met_ppi" ]; then
     export SITE=Linux.MET_PPI
 #    export WORKDIR=/work/$LOGNAME/
 elif [ "$METROMS_MYHOST" == "fram" ]; then
+    export I_MPI_F90=ifort
     export SITE=Linux.fram
 #    export WORKDIR=/work/$LOGNAME/
 else

--- a/apps/common/python/ModelRun.py
+++ b/apps/common/python/ModelRun.py
@@ -162,7 +162,7 @@ class ModelRun(object):
                 print "Profiling not working yet on "+architecture
                 result = 1
             else:
-		result = os.system("mpirun --mca mtl psm2 " + executable + " " + infile)
+		result = os.system("mpirun " + os.path.join(self._params.RUNPATH, executable) + " " + infile)
         else:
             print "Unrecognized architecture!"
             result = 1

--- a/apps/modules.sh
+++ b/apps/modules.sh
@@ -42,12 +42,8 @@ elif [ "$METROMS_MYHOST" == "nebula" ] || [ "$METROMS_MYHOST" == "stratus" ]; th
     #module load Python/2.7.14-anaconda-5.0.1-nsc1
     module load Python/2.7.15-anaconda-5.3.0-extras-nsc1
 elif [ "$METROMS_MYHOST" == "fram" ]; then
-    module load iccifort/2018.3.222-GCC-7.3.0-2.30
-    module load HDF5/1.10.2-intel-2018b
-    module load netCDF/4.6.1-intel-2018b
+    module load intel/2018b
     module load netCDF-Fortran/4.4.4-intel-2018b
-    module load OpenMPI/3.1.1-iccifort-2018.3.222-GCC-7.3.0-2.30
-
     module load Python/2.7.15-intel-2018b
     module load netcdf4-python/1.4.1-intel-2018b-Python-2.7.15
 else


### PR DESCRIPTION
Updated modules used on fram and added `export I_MPI_F90=ifort` when compiling MCT, CICE, ROMS and ROMS_STANDALONE. This fixes issue when certain apps would crash upon initialization when running. Most likely some module version mixup before.