### PR TITLE
added changes to use stress from forcing file

### DIFF
--- a/apps/common/modified_src/roms-trunk1041/bulk_flux.F
+++ b/apps/common/modified_src/roms-trunk1041/bulk_flux.F
@@ -1,0 +1,1113 @@
+#include "cppdefs.h"
+      MODULE bulk_flux_mod
+#ifdef BULK_FLUXES
+!
+!svn $Id: bulk_flux.F 1039 2020-10-12 03:54:49Z arango $
+!================================================== Hernan G. Arango ===
+!  Copyright (c) 2002-2020 The ROMS/TOMS Group                         !
+!    Licensed under a MIT/X style license                              !
+!    See License_ROMS.txt                                              !
+!=======================================================================
+!                                                                      !
+!  This routine computes the bulk parameterization of surface wind     !
+!  stress and surface net heat fluxes.                                 !
+!                                                                      !
+!  References:                                                         !
+!                                                                      !
+!    Fairall, C.W., E.F. Bradley, D.P. Rogers, J.B. Edson and G.S.     !
+!      Young, 1996:  Bulk parameterization of air-sea fluxes for       !
+!      tropical ocean-global atmosphere Coupled-Ocean Atmosphere       !
+!      Response Experiment, JGR, 101, 3747-3764.                       !
+!                                                                      !
+!    Fairall, C.W., E.F. Bradley, J.S. Godfrey, G.A. Wick, J.B.        !
+!      Edson, and G.S. Young, 1996:  Cool-skin and warm-layer          !
+!      effects on sea surface temperature, JGR, 101, 1295-1308.        !
+!                                                                      !
+!    Liu, W.T., K.B. Katsaros, and J.A. Businger, 1979:  Bulk          !
+!        parameterization of the air-sea exchange of heat and          !
+!        water vapor including the molecular constraints at            !
+!        the interface, J. Atmos. Sci, 36, 1722-1735.                  !
+!                                                                      !
+!  Adapted from COARE code written originally by David Rutgers and     !
+!  Frank Bradley.                                                      !
+!                                                                      !
+!  EMINUSP option for equivalent salt fluxes added by Paul Goodman     !
+!  (10/2004).                                                          !
+!                                                                      !
+!  Modified by Kate Hedstrom for COARE version 3.0 (03/2005).          !
+!  Modified by Jim Edson to correct specific humidities.               !
+!                                                                      !
+!  Reference:                                                          !
+!                                                                      !
+!     Fairall et al., 2003: J. Climate, 16, 571-591.                   !
+!                                                                      !
+!     Taylor, P. K., and M. A. Yelland, 2001: The dependence of sea    !
+!     surface roughness on the height and steepness of the waves.      !
+!     J. Phys. Oceanogr., 31, 572-590.                                 !
+!                                                                      !
+!     Oost, W. A., G. J. Komen, C. M. J. Jacobs, and C. van Oort, 2002:!
+!     New evidence for a relation between wind stress and wave age     !
+!     from measurements during ASGAMAGE. Bound.-Layer Meteor., 103,    !
+!     409-438.                                                         !
+!                                                                      !
+!=======================================================================
+!
+      implicit none
+!
+      PRIVATE
+      PUBLIC  :: bulk_flux, bulk_psiu, bulk_psit
+!
+      CONTAINS
+!
+!***********************************************************************
+      SUBROUTINE bulk_flux (ng, tile)
+!***********************************************************************
+!
+      USE mod_param
+      USE mod_forces
+      USE mod_grid
+      USE mod_mixing
+      USE mod_ocean
+      USE mod_stepping
+!
+!  Imported variable declarations.
+!
+      integer, intent(in) :: ng, tile
+!
+!  Local variable declarations.
+!
+# include "tile.h"
+!
+# ifdef PROFILE
+      CALL wclock_on (ng, iNLM, 17, __LINE__, __FILE__)
+# endif
+      CALL bulk_flux_tile (ng, tile,                                    &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     IminS, ImaxS, JminS, JmaxS,                  &
+     &                     nrhs(ng),                                    &
+# ifdef MASKING
+     &                     GRID(ng) % rmask,                            &
+     &                     GRID(ng) % umask,                            &
+     &                     GRID(ng) % vmask,                            &
+# endif
+# ifdef WET_DRY
+     &                     GRID(ng) % rmask_wet,                        &
+     &                     GRID(ng) % umask_wet,                        &
+     &                     GRID(ng) % vmask_wet,                        &
+# endif
+     &                     MIXING(ng) % alpha,                          &
+     &                     MIXING(ng) % beta,                           &
+     &                     OCEAN(ng) % rho,                             &
+     &                     OCEAN(ng) % t,                               &
+# ifdef WIND_MINUS_CURRENT
+     &                     OCEAN(ng) % u,                               &
+     &                     OCEAN(ng) % v,                               &
+# endif
+     &                     FORCES(ng) % Hair,                           &
+     &                     FORCES(ng) % Pair,                           &
+     &                     FORCES(ng) % Tair,                           &
+     &                     FORCES(ng) % Uwind,                          &
+     &                     FORCES(ng) % Vwind,                          &
+# ifdef CLOUDS
+     &                     FORCES(ng) % cloud,                          &
+# endif
+# ifdef COARE_TAYLOR_YELLAND
+     &                     FORCES(ng) % Hwave,                          &
+# endif
+# if defined COARE_TAYLOR_YELLAND || defined COARE_OOST
+     &                     FORCES(ng) % Pwave_top,                      &
+# endif
+# if !defined DEEPWATER_WAVES      && \
+     (defined COARE_TAYLOR_YELLAND || defined COARE_OOST)
+     &                     FORCES(ng) % Lwave,                          &
+# endif
+     &                     FORCES(ng) % rain,                           &
+     &                     FORCES(ng) % lhflx,                          &
+     &                     FORCES(ng) % lrflx,                          &
+     &                     FORCES(ng) % shflx,                          &
+     &                     FORCES(ng) % srflx,                          &
+# ifdef EMINUSP
+     &                     FORCES(ng) % evap,                           &
+# endif
+     &                     FORCES(ng) % stflux,                         &
+     &                     FORCES(ng) % sustr,                          &
+     &                     FORCES(ng) % svstr)
+# ifdef PROFILE
+      CALL wclock_off (ng, iNLM, 17, __LINE__, __FILE__)
+# endif
+
+      RETURN
+      END SUBROUTINE bulk_flux
+!
+!***********************************************************************
+      SUBROUTINE bulk_flux_tile (ng, tile,                              &
+     &                           LBi, UBi, LBj, UBj,                    &
+     &                           IminS, ImaxS, JminS, JmaxS,            &
+     &                           nrhs,                                  &
+# ifdef MASKING
+     &                           rmask, umask, vmask,                   &
+# endif
+# ifdef WET_DRY
+     &                           rmask_wet, umask_wet, vmask_wet,       &
+# endif
+     &                           alpha, beta, rho, t,                   &
+# ifdef WIND_MINUS_CURRENT
+     &                           u, v,                                  &
+# endif
+     &                           Hair, Pair, Tair, Uwind, Vwind,        &
+# ifdef CLOUDS
+     &                           cloud,                                 &
+# endif
+# ifdef COARE_TAYLOR_YELLAND
+     &                           Hwave,                                 &
+# endif
+# if defined COARE_TAYLOR_YELLAND || defined COARE_OOST
+     &                           Pwave_top,                             &
+# endif
+# if !defined DEEPWATER_WAVES      && \
+     (defined COARE_TAYLOR_YELLAND || defined COARE_OOST)
+     &                           Lwave,                                 &
+# endif
+     &                           rain, lhflx, lrflx, shflx, srflx,      &
+# ifdef EMINUSP
+     &                           evap,                                  &
+# endif
+     &                           stflux, sustr, svstr)
+!***********************************************************************
+!
+      USE mod_param
+      USE mod_scalars
+!
+      USE exchange_2d_mod
+# ifdef DISTRIBUTE
+      USE mp_exchange_mod, ONLY : mp_exchange2d
+# endif
+!
+!  Imported variable declarations.
+!
+      integer, intent(in) :: ng, tile
+      integer, intent(in) :: LBi, UBi, LBj, UBj
+      integer, intent(in) :: IminS, ImaxS, JminS, JmaxS
+      integer, intent(in) :: nrhs
+!
+# ifdef ASSUMED_SHAPE
+#  ifdef MASKING
+      real(r8), intent(in) :: rmask(LBi:,LBj:)
+      real(r8), intent(in) :: umask(LBi:,LBj:)
+      real(r8), intent(in) :: vmask(LBi:,LBj:)
+#  endif
+#  ifdef WET_DRY
+      real(r8), intent(in) :: rmask_wet(LBi:,LBj:)
+      real(r8), intent(in) :: umask_wet(LBi:,LBj:)
+      real(r8), intent(in) :: vmask_wet(LBi:,LBj:)
+#  endif
+      real(r8), intent(in) :: alpha(LBi:,LBj:)
+      real(r8), intent(in) :: beta(LBi:,LBj:)
+      real(r8), intent(in) :: rho(LBi:,LBj:,:)
+      real(r8), intent(in) :: t(LBi:,LBj:,:,:,:)
+#  ifdef WIND_MINUS_CURRENT
+      real(r8), intent(in) :: u(LBi:,LBj:,:,:)
+      real(r8), intent(in) :: v(LBi:,LBj:,:,:)
+#  endif
+      real(r8), intent(in) :: Hair(LBi:,LBj:)
+      real(r8), intent(in) :: Pair(LBi:,LBj:)
+      real(r8), intent(in) :: Tair(LBi:,LBj:)
+      real(r8), intent(in) :: Uwind(LBi:,LBj:)
+      real(r8), intent(in) :: Vwind(LBi:,LBj:)
+#  ifdef CLOUDS
+      real(r8), intent(in) :: cloud(LBi:,LBj:)
+#  endif
+# ifdef COARE_TAYLOR_YELLAND
+      real(r8), intent(in) :: Hwave(LBi:,LBj:)
+# endif
+# if defined COARE_TAYLOR_YELLAND || defined COARE_OOST
+      real(r8), intent(in) :: Pwave_top(LBi:,LBj:)
+# endif
+# if !defined DEEPWATER_WAVES      && \
+     (defined COARE_TAYLOR_YELLAND || defined COARE_OOST)
+      real(r8), intent(in) :: Lwave(LBi:,LBj:)
+# endif
+      real(r8), intent(in) :: rain(LBi:,LBj:)
+
+      real(r8), intent(inout) :: lhflx(LBi:,LBj:)
+      real(r8), intent(inout) :: lrflx(LBi:,LBj:)
+      real(r8), intent(inout) :: shflx(LBi:,LBj:)
+      real(r8), intent(inout) :: srflx(LBi:,LBj:)
+      real(r8), intent(inout) :: stflux(LBi:,LBj:,:)
+
+#  ifdef EMINUSP
+      real(r8), intent(out) :: evap(LBi:,LBj:)
+#  endif
+      real(r8), intent(out) :: sustr(LBi:,LBj:)
+      real(r8), intent(out) :: svstr(LBi:,LBj:)
+# else
+#  ifdef MASKING
+      real(r8), intent(in) :: rmask(LBi:UBi,LBj:UBj)
+      real(r8), intent(in) :: umask(LBi:UBi,LBj:UBj)
+      real(r8), intent(in) :: vmask(LBi:UBi,LBj:UBj)
+#  endif
+#  ifdef WET_DRY
+      real(r8), intent(in) :: rmask_wet(LBi:UBi,LBj:UBj)
+      real(r8), intent(in) :: umask_wet(LBi:UBi,LBj:UBj)
+      real(r8), intent(in) :: vmask_wet(LBi:UBi,LBj:UBj)
+#  endif
+      real(r8), intent(in) :: alpha(LBi:UBi,LBj:UBj)
+      real(r8), intent(in) :: beta(LBi:UBi,LBj:UBj)
+      real(r8), intent(in) :: rho(LBi:UBi,LBj:UBj,N(ng))
+      real(r8), intent(in) :: t(LBi:UBi,LBj:UBj,N(ng),3,NT(ng))
+#  ifdef WIND_MINUS_CURRENT
+      real(r8), intent(in) :: u(LBi:UBi,LBj:UBj,N(ng),3)
+      real(r8), intent(in) :: v(LBi:UBi,LBj:UBj,N(ng),3)
+#  endif
+      real(r8), intent(in) :: Hair(LBi:UBi,LBj:UBj)
+      real(r8), intent(in) :: Pair(LBi:UBi,LBj:UBj)
+      real(r8), intent(in) :: Tair(LBi:UBi,LBj:UBj)
+      real(r8), intent(in) :: Uwind(LBi:UBi,LBj:UBj)
+      real(r8), intent(in) :: Vwind(LBi:UBi,LBj:UBj)
+#  ifdef CLOUDS
+      real(r8), intent(in) :: cloud(LBi:UBi,LBj:UBj)
+#  endif
+# ifdef COARE_TAYLOR_YELLAND
+      real(r8), intent(in) :: Hwave(LBi:UBi,LBj:UBj)
+# endif
+# if defined COARE_TAYLOR_YELLAND || defined COARE_OOST
+      real(r8), intent(in) :: Pwave_top(LBi:UBi,LBj:UBj)
+# endif
+# if !defined DEEPWATER_WAVES      && \
+     (defined COARE_TAYLOR_YELLAND || defined COARE_OOST)
+      real(r8), intent(in) :: Lwave(LBi:UBi,LBj:UBj)
+# endif
+      real(r8), intent(in) :: rain(LBi:UBi,LBj:UBj)
+
+      real(r8), intent(inout) :: lhflx(LBi:UBi,LBj:UBj)
+      real(r8), intent(inout) :: lrflx(LBi:UBi,LBj:UBj)
+      real(r8), intent(inout) :: shflx(LBi:UBi,LBj:UBj)
+      real(r8), intent(inout) :: srflx(LBi:UBi,LBj:UBj)
+      real(r8), intent(inout) :: stflux(LBi:UBi,LBj:UBj,NT(ng))
+
+#  ifdef EMINUSP
+      real(r8), intent(out) :: evap(LBi:UBi,LBj:UBj)
+#  endif
+      real(r8), intent(out) :: sustr(LBi:UBi,LBj:UBj)
+      real(r8), intent(out) :: svstr(LBi:UBi,LBj:UBj)
+# endif
+!
+!  Local variable declarations.
+!
+      integer :: Iter, i, j, k
+      integer, parameter :: IterMax = 3
+
+      real(r8), parameter :: eps = 1.0E-20_r8
+      real(r8), parameter :: r3 = 1.0_r8/3.0_r8
+
+      real(r8) :: Bf, Cd, Hl, Hlw, Hscale, Hs, Hsr, IER
+      real(r8) :: PairM,  RH, Taur
+      real(r8) :: Wspeed, ZQoL, ZToL
+
+      real(r8) :: cff, cff1, cff2, diffh, diffw, oL, upvel
+      real(r8) :: twopi_inv, wet_bulb
+# ifdef LONGWAVE
+      real(r8) :: e_sat, vap_p
+# endif
+# ifdef COOL_SKIN
+      real(r8) :: Clam, Fc, Hcool, Hsb, Hlb, Qbouy, Qcool, lambd
+# endif
+
+      real(r8), dimension(IminS:ImaxS) :: CC
+      real(r8), dimension(IminS:ImaxS) :: Cd10
+      real(r8), dimension(IminS:ImaxS) :: Ch10
+      real(r8), dimension(IminS:ImaxS) :: Ct10
+      real(r8), dimension(IminS:ImaxS) :: charn
+      real(r8), dimension(IminS:ImaxS) :: Ct
+      real(r8), dimension(IminS:ImaxS) :: Cwave
+      real(r8), dimension(IminS:ImaxS) :: Cwet
+      real(r8), dimension(IminS:ImaxS) :: delQ
+      real(r8), dimension(IminS:ImaxS) :: delQc
+      real(r8), dimension(IminS:ImaxS) :: delT
+      real(r8), dimension(IminS:ImaxS) :: delTc
+      real(r8), dimension(IminS:ImaxS) :: delW
+      real(r8), dimension(IminS:ImaxS) :: L
+      real(r8), dimension(IminS:ImaxS) :: L10
+      real(r8), dimension(IminS:ImaxS) :: Q
+      real(r8), dimension(IminS:ImaxS) :: Qair
+      real(r8), dimension(IminS:ImaxS) :: Qpsi
+      real(r8), dimension(IminS:ImaxS) :: Qsea
+      real(r8), dimension(IminS:ImaxS) :: Qstar
+      real(r8), dimension(IminS:ImaxS) :: rhoAir
+      real(r8), dimension(IminS:ImaxS) :: rhoSea
+      real(r8), dimension(IminS:ImaxS) :: Ri
+      real(r8), dimension(IminS:ImaxS) :: Ribcu
+      real(r8), dimension(IminS:ImaxS) :: Rr
+      real(r8), dimension(IminS:ImaxS) :: Scff
+      real(r8), dimension(IminS:ImaxS) :: TairC
+      real(r8), dimension(IminS:ImaxS) :: TairK
+      real(r8), dimension(IminS:ImaxS) :: Tcff
+      real(r8), dimension(IminS:ImaxS) :: Tpsi
+      real(r8), dimension(IminS:ImaxS) :: TseaC
+      real(r8), dimension(IminS:ImaxS) :: TseaK
+      real(r8), dimension(IminS:ImaxS) :: Tstar
+      real(r8), dimension(IminS:ImaxS) :: u10
+      real(r8), dimension(IminS:ImaxS) :: VisAir
+      real(r8), dimension(IminS:ImaxS) :: WaveLength
+      real(r8), dimension(IminS:ImaxS) :: Wgus
+      real(r8), dimension(IminS:ImaxS) :: Wmag
+      real(r8), dimension(IminS:ImaxS) :: Wpsi
+      real(r8), dimension(IminS:ImaxS) :: Wstar
+      real(r8), dimension(IminS:ImaxS) :: Zetu
+      real(r8), dimension(IminS:ImaxS) :: Zo10
+      real(r8), dimension(IminS:ImaxS) :: ZoT10
+      real(r8), dimension(IminS:ImaxS) :: ZoL
+      real(r8), dimension(IminS:ImaxS) :: ZoQ
+      real(r8), dimension(IminS:ImaxS) :: ZoT
+      real(r8), dimension(IminS:ImaxS) :: ZoW
+      real(r8), dimension(IminS:ImaxS) :: ZWoL
+
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: Hlv
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: LHeat
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: LRad
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: SHeat
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: SRad
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: Taux
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: Tauy
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: Uair
+      real(r8), dimension(IminS:ImaxS,JminS:JmaxS) :: Vair
+
+# include "set_bounds.h"
+!
+!=======================================================================
+!  Atmosphere-Ocean bulk fluxes parameterization.
+!=======================================================================
+#ifdef WIND_MINUS_CURRENT
+!
+!  Modify near-surface (2m or 10m) effective winds by subtracting the
+!  ocean surface current (J Wilkin). See:
+!
+!  Bye, J.A.T. and J.-O. Wolff, 1999: Atmosphere-ocean momentum exchange
+!     in general circulation models. J. Phys. Oceanogr. 29, 671-691.
+!
+      DO j=Jstr-1,Jend+1
+        DO i=Istr-1,MIN(Iend+1,Lm(ng))
+          Uair(i,j)=Uwind(i,j)-                                         &
+     &              0.5_r8*(u(i,j,N(ng),nrhs)+u(i+1,j,N(ng),nrhs))
+        END DO
+        IF (DOMAIN(ng)%Eastern_Edge(tile)) THEN
+          Uair(Iend+1,j)=Uwind(Iend+1,j)-u(Iend,j,N(ng),nrhs)
+        END IF
+      END DO
+      DO i=Istr-1,Iend+1
+        DO j=Jstr-1,MIN(Jend+1,Mm(ng))
+          Vair(i,j)=Vwind(i,j)-                                         &
+     &              0.5_r8*(v(i,j,N(ng),nrhs)+v(i,j+1,N(ng),nrhs))
+        END DO
+        IF (DOMAIN(ng)%Northern_Edge(tile)) THEN
+          Vair(i,Jend+1)=Vwind(i,Jend+1)-v(i,Jend,N(ng),nrhs)
+        END IF
+      END DO
+#else
+!
+!  Load wind components to local arrays.
+!
+      DO j=Jstr-1,Jend+1
+        DO i=Istr-1,Iend+1
+          Uair(i,j)=Uwind(i,j)
+          Vair(i,j)=Vwind(i,j)
+        END DO
+      END DO
+#endif
+!
+!  Compute Atmosphere-ocean fluxes using a bulk flux parameterization.
+!
+      Hscale=rho0*Cp
+      twopi_inv=0.5_r8/pi
+      DO j=Jstr-1,JendR
+        DO i=Istr-1,IendR
+!
+!  Input bulk parameterization fields.
+!
+          Wmag(i)=SQRT(Uair(i,j)*Uair(i,j)+Vair(i,j)*Vair(i,j))
+          PairM=Pair(i,j)
+          TairC(i)=Tair(i,j)
+          TairK(i)=TairC(i)+273.16_r8
+          TseaC(i)=t(i,j,N(ng),nrhs,itemp)
+          TseaK(i)=TseaC(i)+273.16_r8
+          rhoSea(i)=rho(i,j,N(ng))+1000.0_r8
+          RH=Hair(i,j)
+          SRad(i,j)=srflx(i,j)*Hscale
+          Tcff(i)=alpha(i,j)
+          Scff(i)=beta(i,j)
+!
+!  Initialize.
+!
+          delTc(i)=0.0_r8
+          delQc(i)=0.0_r8
+          LHeat(i,j)=lhflx(i,j)*Hscale
+          SHeat(i,j)=shflx(i,j)*Hscale
+          Taur=0.0_r8
+          Taux(i,j)=0.0_r8
+          Tauy(i,j)=0.0_r8
+!
+!-----------------------------------------------------------------------
+!  Compute net longwave radiation (W/m2), LRad.
+!-----------------------------------------------------------------------
+
+# if defined LONGWAVE
+!
+!  Use Berliand (1952) formula to calculate net longwave radiation.
+!  The equation for saturation vapor pressure is from Gill (Atmosphere-
+!  Ocean Dynamics, pp 606). Here the coefficient in the cloud term
+!  is assumed constant, but it is a function of latitude varying from
+!  1.0 at poles to 0.5 at the Equator).
+!
+          cff=(0.7859_r8+0.03477_r8*TairC(i))/                          &
+     &        (1.0_r8+0.00412_r8*TairC(i))
+          e_sat=10.0_r8**cff   ! saturation vapor pressure (hPa or mbar)
+          vap_p=e_sat*RH       ! water vapor pressure (hPa or mbar)
+          cff2=TairK(i)*TairK(i)*TairK(i)
+          cff1=cff2*TairK(i)
+          LRad(i,j)=-emmiss*StefBo*                                     &
+     &              (cff1*(0.39_r8-0.05_r8*SQRT(vap_p))*                &
+     &                    (1.0_r8-0.6823_r8*cloud(i,j)*cloud(i,j))+     &
+     &               cff2*4.0_r8*(TseaK(i)-TairK(i)))
+
+# elif defined LONGWAVE_OUT
+!
+!  Treat input longwave data as downwelling radiation only and add
+!  outgoing IR from model sea surface temperature.
+!
+          LRad(i,j)=lrflx(i,j)*Hscale-                                  &
+     &              emmiss*StefBo*TseaK(i)*TseaK(i)*TseaK(i)*TseaK(i)
+
+# else
+          LRad(i,j)=lrflx(i,j)*Hscale
+# endif
+# ifdef MASKING
+          LRad(i,j)=LRad(i,j)*rmask(i,j)
+# endif
+# ifdef WET_DRY
+          LRad(i,j)=LRad(i,j)*rmask_wet(i,j)
+# endif
+!
+!-----------------------------------------------------------------------
+!  Compute specific humidities (kg/kg).
+!
+!    note that Qair(i) is the saturation specific humidity at Tair
+!                 Q(i) is the actual specific humidity
+!              Qsea(i) is the saturation specific humidity at Tsea
+!
+!          Saturation vapor pressure in mb is first computed and then
+!          converted to specific humidity in kg/kg
+!
+!          The saturation vapor pressure is computed from Teten formula
+!          using the approach of Buck (1981):
+!
+!          Esat(mb) = (1.0007_r8+3.46E-6_r8*PairM(mb))*6.1121_r8*
+!                  EXP(17.502_r8*TairC(C)/(240.97_r8+TairC(C)))
+!
+!          The ambient vapor is found from the definition of the
+!          Relative humidity:
+!
+!          RH = W/Ws*100 ~ E/Esat*100   E = RH/100*Esat if RH is in %
+!                                       E = RH*Esat     if RH fractional
+!
+!          The specific humidity is then found using the relationship:
+!
+!          Q = 0.622 E/(P + (0.622-1)e)
+!
+!          Q(kg/kg) = 0.62197_r8*(E(mb)/(PairM(mb)-0.378_r8*E(mb)))
+!
+!-----------------------------------------------------------------------
+!
+!  Compute air saturation vapor pressure (mb), using Teten formula.
+!
+          cff=(1.0007_r8+3.46E-6_r8*PairM)*6.1121_r8*                   &
+     &        EXP(17.502_r8*TairC(i)/(240.97_r8+TairC(i)))
+!
+!  Compute specific humidity at Saturation, Qair (kg/kg).
+!
+          Qair(i)=0.62197_r8*(cff/(PairM-0.378_r8*cff))
+!
+!  Compute specific humidity, Q (kg/kg).
+!
+          IF (RH.lt.2.0_r8) THEN                       !RH fraction
+            cff=cff*RH                                 !Vapor pres (mb)
+            Q(i)=0.62197_r8*(cff/(PairM-0.378_r8*cff)) !Spec hum (kg/kg)
+          ELSE          !RH input was actually specific humidity in g/kg
+            Q(i)=RH/1000.0_r8                          !Spec Hum (kg/kg)
+          END IF
+!
+!  Compute water saturation vapor pressure (mb), using Teten formula.
+!
+          cff=(1.0007_r8+3.46E-6_r8*PairM)*6.1121_r8*                   &
+     &        EXP(17.502_r8*TseaC(i)/(240.97_r8+TseaC(i)))
+!
+!  Vapor Pressure reduced for salinity (Kraus & Businger, 1994, pp 42).
+!
+          cff=cff*0.98_r8
+!
+!  Compute Qsea (kg/kg) from vapor pressure.
+!
+          Qsea(i)=0.62197_r8*(cff/(PairM-0.378_r8*cff))
+!
+!-----------------------------------------------------------------------
+!  Compute Monin-Obukhov similarity parameters for wind (Wstar),
+!  heat (Tstar), and moisture (Qstar), Liu et al. (1979).
+!-----------------------------------------------------------------------
+!
+!  Moist air density (kg/m3).
+!
+          rhoAir(i)=PairM*100.0_r8/(blk_Rgas*TairK(i)*                  &
+     &                              (1.0_r8+0.61_r8*Q(i)))
+!
+!  Kinematic viscosity of dry air (m2/s), Andreas (1989).
+!
+          VisAir(i)=1.326E-5_r8*                                        &
+     &              (1.0_r8+TairC(i)*(6.542E-3_r8+TairC(i)*             &
+     &               (8.301E-6_r8-4.84E-9_r8*TairC(i))))
+!
+!  Compute latent heat of vaporization (J/kg) at sea surface, Hlv.
+!
+#ifdef REGCM_COUPLING
+          Hlv(i,j)=2.5104E+6_r8 ! to be consistent with RegCM
+#else
+          Hlv(i,j)=(2.501_r8-0.00237_r8*TseaC(i))*1.0E+6_r8
+#endif
+!
+!  Assume that wind is measured relative to sea surface and include
+!  gustiness.
+!
+          Wgus(i)=0.5_r8
+          delW(i)=SQRT(Wmag(i)*Wmag(i)+Wgus(i)*Wgus(i))
+          delQ(i)=Qsea(i)-Q(i)
+          delT(i)=TseaC(i)-TairC(i)
+!
+!  Neutral coefficients.
+!
+          ZoW(i)=0.0001_r8
+          u10(i)=delW(i)*LOG(10.0_r8/ZoW(i))/LOG(blk_ZW(ng)/ZoW(i))
+          Wstar(i)=0.035_r8*u10(i)
+          Zo10(i)=0.011_r8*Wstar(i)*Wstar(i)/g+                         &
+     &            0.11_r8*VisAir(i)/Wstar(i)
+          Cd10(i)=(vonKar/LOG(10.0_r8/Zo10(i)))**2
+          Ch10(i)=0.00115_r8
+          Ct10(i)=Ch10(i)/sqrt(Cd10(i))
+          ZoT10(i)=10.0_r8/EXP(vonKar/Ct10(i))
+          Cd=(vonKar/LOG(blk_ZW(ng)/Zo10(i)))**2
+!
+!  Compute Richardson number.
+!
+          Ct(i)=vonKar/LOG(blk_ZT(ng)/ZoT10(i))  ! T transfer coefficient
+          CC(i)=vonKar*Ct(i)/Cd
+          delTc(i)=0.0_r8
+# ifdef COOL_SKIN
+          delTc(i)=blk_dter
+# endif
+          Ribcu(i)=-blk_ZW(ng)/(blk_Zabl*0.004_r8*blk_beta**3)
+          Ri(i)=-g*blk_ZW(ng)*((delT(i)-delTc(i))+                      &
+     &                          0.61_r8*TairK(i)*delQ(i))/              &
+     &          (TairK(i)*delW(i)*delW(i))
+          IF (Ri(i).lt.0.0_r8) THEN
+            Zetu(i)=CC(i)*Ri(i)/(1.0_r8+Ri(i)/Ribcu(i))       ! Unstable
+          ELSE
+            Zetu(i)=CC(i)*Ri(i)/(1.0_r8+3.0_r8*Ri(i)/CC(i))   ! Stable
+          END IF
+          L10(i)=blk_ZW(ng)/Zetu(i)
+!
+!  First guesses for Monon-Obukhov similarity scales.
+!
+          Wstar(i)=delW(i)*vonKar/(LOG(blk_ZW(ng)/Zo10(i))-             &
+     &                             bulk_psiu(blk_ZW(ng)/L10(i),pi))
+          Tstar(i)=-(delT(i)-delTc(i))*vonKar/                          &
+     &             (LOG(blk_ZT(ng)/ZoT10(i))-                           &
+     &              bulk_psit(blk_ZT(ng)/L10(i),pi))
+          Qstar(i)=-(delQ(i)-delQc(i))*vonKar/                          &
+     &             (LOG(blk_ZQ(ng)/ZoT10(i))-                           &
+     &              bulk_psit(blk_ZQ(ng)/L10(i),pi))
+!
+!  Modify Charnock for high wind speeds. The 0.125 factor below is for
+!  1.0/(18.0-10.0).
+!
+          IF (delW(i).gt.18.0_r8) THEN
+            charn(i)=0.018_r8
+          ELSE IF ((10.0_r8.lt.delW(i)).and.(delW(i).le.18.0_r8)) THEN
+            charn(i)=0.011_r8+                                          &
+     &               0.125_r8*(0.018_r8-0.011_r8)*(delW(i)-10._r8)
+          ELSE
+            charn(i)=0.011_r8
+          END IF
+# if defined COARE_OOST || defined COARE_TAYLOR_YELLAND
+#  if defined DEEPWATER_WAVES
+          Cwave(i)=g*MAX(Pwave_top(i,j),eps)*twopi_inv
+          WaveLength(i)=Cwave(i)*MAX(Pwave_top(i,j),eps)
+#  else
+          Cwave(i)=Lwave(i,j)/MAX(Pwave_top(i,j),eps)
+          WaveLength(i)=Lwave(i,j)
+#  endif
+# endif
+        END DO
+!
+!  Iterate until convergence. It usually converges within 3 iterations.
+# if defined COARE_OOST || defined COARE_TAYLOR_YELLAND
+!  Use wave info if we have it, two different options.
+# endif
+!
+        DO Iter=1,IterMax
+          DO i=Istr-1,IendR
+# ifdef COARE_OOST
+            ZoW(i)=(25.0_r8/pi)*WaveLength(i)*                          &
+     &             (Wstar(i)/Cwave(i))**4.5_r8+                         &
+     &             0.11_r8*VisAir(i)/(Wstar(i)+eps)
+# elif defined COARE_TAYLOR_YELLAND
+            ZoW(i)=1200.0_r8*Hwave(i,j)*                                &
+     &             (Hwave(i,j)/WaveLength(i))**4.5_r8+                  &
+     &             0.11_r8*VisAir(i)/(Wstar(i)+eps)
+# else
+            ZoW(i)=charn(i)*Wstar(i)*Wstar(i)/g+                        &
+     &             0.11_r8*VisAir(i)/(Wstar(i)+eps)
+# endif
+            Rr(i)=ZoW(i)*Wstar(i)/VisAir(i)
+!
+!  Compute Monin-Obukhov stability parameter, Z/L.
+!
+            ZoQ(i)=MIN(1.15e-4_r8,5.5e-5_r8/Rr(i)**0.6_r8)
+            ZoT(i)=ZoQ(i)
+            ZoL(i)=vonKar*g*blk_ZW(ng)*                                 &
+     &             (Tstar(i)*(1.0_r8+0.61_r8*Q(i))+                     &
+     &                        0.61_r8*TairK(i)*Qstar(i))/               &
+     &             (TairK(i)*Wstar(i)*Wstar(i)*                         &
+     &              (1.0_r8+0.61_r8*Q(i))+eps)
+            L(i)=blk_ZW(ng)/(ZoL(i)+eps)
+!
+!  Evaluate stability functions at Z/L.
+!
+            Wpsi(i)=bulk_psiu(ZoL(i),pi)
+            Tpsi(i)=bulk_psit(blk_ZT(ng)/L(i),pi)
+            Qpsi(i)=bulk_psit(blk_ZQ(ng)/L(i),pi)
+# ifdef COOL_SKIN
+            Cwet(i)=0.622_r8*Hlv(i,j)*Qsea(i)/                          &
+     &              (blk_Rgas*TseaK(i)*TseaK(i))
+            delQc(i)=Cwet(i)*delTc(i)
+# endif
+!
+!  Compute wind scaling parameters, Wstar.
+!
+            Wstar(i)=MAX(eps,delW(i)*vonKar/                            &
+     &               (LOG(blk_ZW(ng)/ZoW(i))-Wpsi(i)))
+            Tstar(i)=-(delT(i)-delTc(i))*vonKar/                        &
+     &               (LOG(blk_ZT(ng)/ZoT(i))-Tpsi(i))
+            Qstar(i)=-(delQ(i)-delQc(i))*vonKar/                        &
+     &               (LOG(blk_ZQ(ng)/ZoQ(i))-Qpsi(i))
+!
+!  Compute gustiness in wind speed.
+!
+            Bf=-g/TairK(i)*                                             &
+     &         Wstar(i)*(Tstar(i)+0.61_r8*TairK(i)*Qstar(i))
+            IF (Bf.gt.0.0_r8) THEN
+              Wgus(i)=blk_beta*(Bf*blk_Zabl)**r3
+            ELSE
+              Wgus(i)=0.2_r8
+            END IF
+            delW(i)=SQRT(Wmag(i)*Wmag(i)+Wgus(i)*Wgus(i))
+# ifdef COOL_SKIN
+!
+!-----------------------------------------------------------------------
+!  Cool Skin correction.
+!-----------------------------------------------------------------------
+!
+!  Cool skin correction constants. Clam: part of Saunders constant
+!  lambda; Cwet: slope of saturation vapor.
+!
+            Clam=16.0_r8*g*blk_Cpw*(rhoSea(i)*blk_visw)**3.0_r8/        &
+     &           (blk_tcw*blk_tcw*rhoAir(i)*rhoAir(i))
+!
+!  Set initial guesses for cool-skin layer thickness (Hcool).
+!
+            Hcool=0.001_r8
+!
+!  Backgound sensible and latent heat.
+!
+            Hsb=-rhoAir(i)*blk_Cpa*Wstar(i)*Tstar(i)
+            Hlb=-rhoAir(i)*Hlv(i,j)*Wstar(i)*Qstar(i)
+!
+!  Mean absoption in cool-skin layer.
+!
+            Fc=0.065_r8+11.0_r8*Hcool-                                  &
+     &         (1.0_r8-EXP(-Hcool*1250.0_r8))*6.6E-5_r8/Hcool
+!
+!  Total cooling at the interface.
+!
+            Qcool=LRad(i,j)+Hsb+Hlb-SRad(i,j)*Fc
+            Qbouy=Tcff(i)*Qcool+Scff(i)*Hlb*blk_Cpw/Hlv(i,j)
+!
+!  Compute temperature and moisture change.
+!
+            IF ((Qcool.gt.0.0_r8).and.(Qbouy.gt.0.0_r8)) THEN
+              lambd=6.0_r8/                                             &
+     &              (1.0_r8+                                            &
+     &               (Clam*Qbouy/(Wstar(i)+eps)**4.0_r8)**0.75_r8)**r3
+              Hcool=lambd*blk_visw/(SQRT(rhoAir(i)/rhoSea(i))*          &
+     &                              Wstar(i)+eps)
+              delTc(i)=Qcool*Hcool/blk_tcw
+            ELSE
+              delTc(i)=0.0_r8
+            END IF
+            delQc(i)=Cwet(i)*delTc(i)
+# endif
+          END DO
+        END DO
+!
+!-----------------------------------------------------------------------
+!  Compute Atmosphere/Ocean fluxes.
+!-----------------------------------------------------------------------
+!
+        DO i=Istr-1,IendR
+!
+!  Compute transfer coefficients for momentum (Cd).
+!
+          Wspeed=SQRT(Wmag(i)*Wmag(i)+Wgus(i)*Wgus(i))
+          Cd=Wstar(i)*Wstar(i)/(Wspeed*Wspeed+eps)
+!
+!  Compute turbulent sensible heat flux (W/m2), Hs.
+!
+          Hs=-blk_Cpa*rhoAir(i)*Wstar(i)*Tstar(i)
+!
+!  Compute sensible heat flux (W/m2) due to rainfall (kg/m2/s), Hsr.
+!
+          diffw=2.11E-5_r8*(TairK(i)/273.16_r8)**1.94_r8
+          diffh=0.02411_r8*(1.0_r8+TairC(i)*                            &
+     &                      (3.309E-3_r8-1.44E-6_r8*TairC(i)))/         &
+     &          (rhoAir(i)*blk_Cpa)
+          cff=Qair(i)*Hlv(i,j)/(blk_Rgas*TairK(i)*TairK(i))
+          wet_bulb=1.0_r8/(1.0_r8+0.622_r8*(cff*Hlv(i,j)*diffw)/        &
+     &                                     (blk_Cpa*diffh))
+          Hsr=rain(i,j)*wet_bulb*blk_Cpw*                               &
+     &        ((TseaC(i)-TairC(i))+(Qsea(i)-Q(i))*Hlv(i,j)/blk_Cpa)
+# ifndef REGCM_COUPLING
+          SHeat(i,j)=(Hs+Hsr)
+# endif
+# ifdef MASKING
+          SHeat(i,j)=SHeat(i,j)*rmask(i,j)
+# endif
+# ifdef WET_DRY
+          SHeat(i,j)=SHeat(i,j)*rmask_wet(i,j)
+# endif
+!
+!  Compute turbulent latent heat flux (W/m2), Hl.
+!
+          Hl=-Hlv(i,j)*rhoAir(i)*Wstar(i)*Qstar(i)
+!
+!  Compute Webb correction (Webb effect) to latent heat flux, Hlw.
+!
+          upvel=-1.61_r8*Wstar(i)*Qstar(i)-                             &
+     &          (1.0_r8+1.61_r8*Q(i))*Wstar(i)*Tstar(i)/TairK(i)
+          Hlw=rhoAir(i)*Hlv(i,j)*upvel*Q(i)
+# ifndef REGCM_COUPLING
+          LHeat(i,j)=(Hl+Hlw)
+# endif
+# ifdef MASKING
+          LHeat(i,j)=LHeat(i,j)*rmask(i,j)
+# endif
+# ifdef WET_DRY
+          LHeat(i,j)=LHeat(i,j)*rmask_wet(i,j)
+# endif
+!
+!  Compute momentum flux (N/m2) due to rainfall (kg/m2/s).
+!
+          Taur=0.85_r8*rain(i,j)*Wmag(i)
+!
+!  Compute wind stress components (N/m2), Tau.
+!
+          cff=rhoAir(i)*Cd*Wspeed
+          Taux(i,j)=(cff*Uair(i,j)+Taur*SIGN(1.0_r8,Uair(i,j)))
+# ifdef MASKING
+          Taux(i,j)=Taux(i,j)*rmask(i,j)
+# endif
+# ifdef WET_DRY
+          Taux(i,j)=Taux(i,j)*rmask_wet(i,j)
+# endif
+          Tauy(i,j)=(cff*Vair(i,j)+Taur*SIGN(1.0_r8,Vair(i,j)))
+# ifdef MASKING
+          Tauy(i,j)=Tauy(i,j)*rmask(i,j)
+# endif
+# ifdef WET_DRY
+          Tauy(i,j)=Tauy(i,j)*rmask_wet(i,j)
+# endif
+        END DO
+      END DO
+!
+!=======================================================================
+!  Compute surface net heat flux and surface wind stress.
+!=======================================================================
+!
+!  Compute kinematic, surface, net heat flux (degC m/s).  Notice that
+!  the signs of latent and sensible fluxes are reversed because fluxes
+!  calculated from the bulk formulations above are positive out of the
+!  ocean.
+!
+!  For EMINUSP option,  EVAP = LHeat (W/m2) / Hlv (J/kg) = kg/m2/s
+!                       PREC = rain = kg/m2/s
+!
+!  To convert these rates to m/s divide by freshwater density, rhow.
+!
+!  Note that when the air is undersaturated in water vapor (Q < Qsea)
+!  the model will evaporate and LHeat > 0:
+!
+!                   LHeat positive out of the ocean
+!                    evap positive out of the ocean
+!
+!  Note that if evaporating, the salt flux is positive
+!        and if     raining, the salt flux is negative
+!
+!  Note that stflux(:,:,isalt) is the E-P flux. The fresh water flux
+!  is positive out of the ocean and the salt flux is positive into the
+!  ocean. It is  multiplied by surface salinity when computing state
+!  variable stflx(:,:,isalt) in "set_vbc.F".
+!
+      Hscale=1.0_r8/(rho0*Cp)
+      cff=1.0_r8/rhow
+      DO j=JstrR,JendR
+        DO i=IstrR,IendR
+          lrflx(i,j)=LRad(i,j)*Hscale
+          lhflx(i,j)=-LHeat(i,j)*Hscale
+          shflx(i,j)=-SHeat(i,j)*Hscale
+          stflux(i,j,itemp)=(srflx(i,j)+lrflx(i,j)+                     &
+     &                       lhflx(i,j)+shflx(i,j))
+# ifdef MASKING
+          stflux(i,j,itemp)=stflux(i,j,itemp)*rmask(i,j)
+# endif
+# ifdef WET_DRY
+          stflux(i,j,itemp)=stflux(i,j,itemp)*rmask_wet(i,j)
+# endif
+# ifdef EMINUSP
+          evap(i,j)=LHeat(i,j)/Hlv(i,j)
+#  ifdef MASKING
+          evap(i,j)=evap(i,j)*rmask(i,j)
+#  endif
+#  ifdef WET_DRY
+          evap(i,j)=evap(i,j)*rmask_wet(i,j)
+#  endif
+          stflux(i,j,isalt)=cff*(evap(i,j)-rain(i,j))
+#  ifdef MASKING
+          stflux(i,j,isalt)=stflux(i,j,isalt)*rmask(i,j)
+#  endif
+#  ifdef WET_DRY
+          stflux(i,j,isalt)=stflux(i,j,isalt)*rmask_wet(i,j)
+#  endif
+# endif
+        END DO
+      END DO
+!
+!  Compute kinematic, surface wind stress (m2/s2).
+!
+# ifndef READ_STRESS
+      cff=0.5_r8/rho0
+      DO j=JstrR,JendR
+        DO i=Istr,IendR
+          sustr(i,j)=cff*(Taux(i-1,j)+Taux(i,j))
+#  ifdef MASKING
+          sustr(i,j)=sustr(i,j)*umask(i,j)
+#  endif
+#  ifdef WET_DRY
+          sustr(i,j)=sustr(i,j)*umask_wet(i,j)
+#  endif
+        END DO
+      END DO
+      DO j=Jstr,JendR
+        DO i=IstrR,IendR
+          svstr(i,j)=cff*(Tauy(i,j-1)+Tauy(i,j))
+#  ifdef MASKING
+          svstr(i,j)=svstr(i,j)*vmask(i,j)
+#  endif
+#  ifdef WET_DRY
+          svstr(i,j)=svstr(i,j)*vmask_wet(i,j)
+#  endif
+        END DO
+      END DO
+# endif
+!
+!-----------------------------------------------------------------------
+!  Exchange boundary data.
+!-----------------------------------------------------------------------
+!
+      IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
+        CALL exchange_r2d_tile (ng, tile,                               &
+     &                          LBi, UBi, LBj, UBj,                     &
+     &                          lrflx)
+        CALL exchange_r2d_tile (ng, tile,                               &
+     &                          LBi, UBi, LBj, UBj,                     &
+     &                          lhflx)
+        CALL exchange_r2d_tile (ng, tile,                               &
+     &                          LBi, UBi, LBj, UBj,                     &
+     &                          shflx)
+        CALL exchange_r2d_tile (ng, tile,                               &
+     &                          LBi, UBi, LBj, UBj,                     &
+     &                          stflux(:,:,itemp))
+# ifdef EMINUSP
+        CALL exchange_r2d_tile (ng, tile,                               &
+     &                          LBi, UBi, LBj, UBj,                     &
+     &                          evap)
+        CALL exchange_r2d_tile (ng, tile,                               &
+     &                          LBi, UBi, LBj, UBj,                     &
+     &                          stflux(:,:,isalt))
+# endif
+        CALL exchange_u2d_tile (ng, tile,                               &
+     &                          LBi, UBi, LBj, UBj,                     &
+     &                          sustr)
+        CALL exchange_v2d_tile (ng, tile,                               &
+     &                          LBi, UBi, LBj, UBj,                     &
+     &                          svstr)
+      END IF
+
+# ifdef DISTRIBUTE
+      CALL mp_exchange2d (ng, tile, iNLM, 4,                            &
+     &                    LBi, UBi, LBj, UBj,                           &
+     &                    NghostPoints,                                 &
+     &                    EWperiodic(ng), NSperiodic(ng),               &
+     &                    lrflx, lhflx, shflx,                          &
+     &                    stflux(:,:,itemp))
+#  ifdef EMINUSP
+      CALL mp_exchange2d (ng, tile, iNLM, 2,                            &
+     &                    LBi, UBi, LBj, UBj,                           &
+     &                    NghostPoints,                                 &
+     &                    EWperiodic(ng), NSperiodic(ng),               &
+     &                    evap,                                         &
+     &                    stflux(:,:,isalt))
+#  endif
+      CALL mp_exchange2d (ng, tile, iNLM, 2,                            &
+     &                    LBi, UBi, LBj, UBj,                           &
+     &                    NghostPoints,                                 &
+     &                    EWperiodic(ng), NSperiodic(ng),               &
+     &                    sustr, svstr)
+# endif
+
+      RETURN
+      END SUBROUTINE bulk_flux_tile
+
+      FUNCTION bulk_psiu (ZoL, pi)
+!
+!=======================================================================
+!                                                                      !
+!  This function evaluates the stability function for  wind speed      !
+!  by matching Kansas  and free convection forms.  The convective      !
+!  form follows Fairall et al. (1996) with profile constants from      !
+!  Grachev et al. (2000) BLM.  The  stable  form is from Beljaars      !
+!  and Holtslag (1991).                                                !
+!                                                                      !
+!=======================================================================
+!
+      USE mod_kinds
+!
+!  Function result
+!
+      real(r8) :: bulk_psiu
+!
+!  Imported variable declarations.
+!
+      real(dp), intent(in) :: pi
+      real(r8), intent(in) :: ZoL
+!
+!  Local variable declarations.
+!
+      real(r8), parameter :: r3 = 1.0_r8/3.0_r8
+
+      real(r8) :: Fw, cff, psic, psik, x, y
+!
+!-----------------------------------------------------------------------
+!  Compute stability function, PSI.
+!-----------------------------------------------------------------------
+!
+!  Unstable conditions.
+!
+      IF (ZoL.lt.0.0_r8) THEN
+        x=(1.0_r8-15.0_r8*ZoL)**0.25_r8
+        psik=2.0_r8*LOG(0.5_r8*(1.0_r8+x))+                             &
+     &       LOG(0.5_r8*(1.0_r8+x*x))-                                  &
+     &       2.0_r8*ATAN(x)+0.5_r8*pi
+!
+!  For very unstable conditions, use free-convection (Fairall).
+!
+        cff=SQRT(3.0_r8)
+        y=(1.0_r8-10.15_r8*ZoL)**r3
+        psic=1.5_r8*LOG(r3*(1.0_r8+y+y*y))-                             &
+     &       cff*ATAN((1.0_r8+2.0_r8*y)/cff)+pi/cff
+!
+!  Match Kansas and free-convection forms with weighting Fw.
+!
+        cff=ZoL*ZoL
+        Fw=cff/(1.0_r8+cff)
+        bulk_psiu=(1.0_r8-Fw)*psik+Fw*psic
+!
+!  Stable conditions.
+!
+      ELSE
+        cff=MIN(50.0_r8,0.35_r8*ZoL)
+        bulk_psiu=-((1.0_r8+ZoL)+0.6667_r8*(ZoL-14.28_r8)/              &
+     &            EXP(cff)+8.525_r8)
+      END IF
+      RETURN
+      END FUNCTION bulk_psiu
+
+      FUNCTION bulk_psit (ZoL, pi)
+!
+!=======================================================================
+!                                                                      !
+!  This function evaluates the  stability function  for moisture and   !
+!  heat by matching Kansas and free convection forms. The convective   !
+!  form follows Fairall et al. (1996) with  profile  constants  from   !
+!  Grachev et al. (2000) BLM.  The stable form is from  Beljaars and   !
+!  and Holtslag (1991).                                                !
+!
+!=======================================================================
+!                                                                      !
+!
+      USE mod_kinds
+!
+!  Function result
+!
+      real(r8) :: bulk_psit
+!
+!  Imported variable declarations.
+!
+      real(dp), intent(in) :: pi
+      real(r8), intent(in) :: ZoL
+!
+!  Local variable declarations.
+!
+      real(r8), parameter :: r3 = 1.0_r8/3.0_r8
+
+      real(r8) :: Fw, cff, psic, psik, x, y
+!
+!-----------------------------------------------------------------------
+!  Compute stability function, PSI.
+!-----------------------------------------------------------------------
+!
+!  Unstable conditions.
+!
+      IF (ZoL.lt.0.0_r8) THEN
+        x=(1.0_r8-15.0_r8*ZoL)**0.5_r8
+        psik=2.0_r8*LOG(0.5_r8*(1.0_r8+x))
+!
+!  For very unstable conditions, use free-convection (Fairall).
+!
+        cff=SQRT(3.0_r8)
+        y=(1.0_r8-34.15_r8*ZoL)**r3
+        psic=1.5_r8*LOG(r3*(1.0_r8+y+y*y))-                             &
+     &       cff*ATAN((1.0_r8+2.0_r8*y)/cff)+pi/cff
+!
+!  Match Kansas and free-convection forms with weighting Fw.
+!
+        cff=ZoL*ZoL
+        Fw=cff/(1.0_r8+cff)
+        bulk_psit=(1.0_r8-Fw)*psik+Fw*psic
+!
+!  Stable conditions.
+!
+      ELSE
+        cff=MIN(50.0_r8,0.35_r8*ZoL)
+        bulk_psit=-((1.0_r8+2.0_r8*ZoL)**1.5_r8+                        &
+     &            0.6667_r8*(ZoL-14.28_r8)/EXP(cff)+8.525_r8)
+      END IF
+
+      RETURN
+      END FUNCTION bulk_psit
+#endif
+      END MODULE bulk_flux_mod

--- a/apps/common/modified_src/roms-trunk1041/get_data.F
+++ b/apps/common/modified_src/roms-trunk1041/get_data.F
@@ -1,0 +1,1334 @@
+#include "cppdefs.h"
+      SUBROUTINE get_data (ng)
+!
+!svn $Id: get_data.F 1041 2020-10-16 00:00:17Z arango $
+!================================================== Hernan G. Arango ===
+!  Copyright (c) 2002-2020 The ROMS/TOMS Group                         !
+!    Licensed under a MIT/X style license                              !
+!    See License_ROMS.txt                                              !
+!=======================================================================
+!                                                                      !
+!  This routine reads in forcing, climatology and other data from      !
+!  NetCDF files.  If there is more than one time-record,  data is      !
+!  loaded into global  two-time  record arrays. The interpolation      !
+!  is carried elsewhere.                                               !
+!                                                                      !
+!  Currently, this routine is only executed in serial mode by the      !
+!  main thread.                                                        !
+!                                                                      !
+!=======================================================================
+!
+      USE mod_param
+#if defined HYPOXIA_SRM || defined RED_TIDE
+      USE mod_biology
+#endif
+      USE mod_boundary
+      USE mod_clima
+      USE mod_forces
+      USE mod_grid
+      USE mod_iounits
+      USE mod_ncparam
+#if defined HYPOXIA_SRM              || \
+    defined NLM_OUTER                || \
+    defined RBL4DVAR                 || \
+    defined RBL4DVAR_ANA_SENSITIVITY || \
+    defined RBL4DVAR_FCT_SENSITIVITY || \
+    defined RED_TIDE                 || \
+    defined SP4DVAR                  || \
+    defined TLM_CHECK                || \
+    defined TL_RBL4DVAR
+      USE mod_ocean
+#endif
+      USE mod_scalars
+      USE mod_sources
+      USE mod_stepping
+!
+      USE strings_mod, ONLY : FoundError
+!
+      implicit none
+!
+!  Imported variable declarations.
+!
+      integer, intent(in) :: ng
+!
+!  Local variable declarations.
+!
+      logical :: Lprocess
+
+      logical, dimension(3) :: update = (/ .FALSE., .FALSE., .FALSE. /)
+!
+      integer :: ILB, IUB, JLB, JUB
+      integer :: LBi, UBi, LBj, UBj
+      integer :: i, ic, my_tile
+!
+!  Lower and upper bounds for nontiled (global values) boundary arrays.
+!
+      my_tile=-1                           ! for global values
+      ILB=BOUNDS(ng)%LBi(my_tile)
+      IUB=BOUNDS(ng)%UBi(my_tile)
+      JLB=BOUNDS(ng)%LBj(my_tile)
+      JUB=BOUNDS(ng)%UBj(my_tile)
+!
+!  Lower and upper bounds for tiled arrays.
+!
+      LBi=LBOUND(GRID(ng)%h,DIM=1)
+      UBi=UBOUND(GRID(ng)%h,DIM=1)
+      LBj=LBOUND(GRID(ng)%h,DIM=2)
+      UBj=UBOUND(GRID(ng)%h,DIM=2)
+
+#ifdef PROFILE
+!
+!-----------------------------------------------------------------------
+!  Turn on input data time wall clock.
+!-----------------------------------------------------------------------
+!
+      CALL wclock_on (ng, iNLM, 3, __LINE__, __FILE__)
+#endif
+
+#ifndef ANA_PSOURCE
+!
+!=======================================================================
+!  Point Sources/Sinks time dependent data.
+!=======================================================================
+!
+!  Point Source/Sink vertically integrated mass transport.
+!
+      IF (LuvSrc(ng).or.LwSrc(ng)) THEN
+        CALL get_ngfld (ng, iNLM, idRtra, SSF(ng)%ncid,                 &
+     &                  1, SSF(ng), update(1),                          &
+     &                  1, Nsrc(ng), 1, 2, 1, Nsrc(ng), 1,              &
+     &                  SOURCES(ng) % QbarG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+
+# ifdef SOLVE3D
+!
+!  Tracer Sources/Sinks.
+!
+      DO i=1,NT(ng)
+        IF (LtracerSrc(i,ng)) THEN
+          CALL get_ngfld (ng, iNLM, idRtrc(i), SSF(ng)%ncid,            &
+     &                    1, SSF(ng), update(1),                        &
+     &                    1, Nsrc(ng), N(ng), 2, 1, Nsrc(ng), N(ng),    &
+     &                    SOURCES(ng) % TsrcG(:,:,:,i))
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+      END DO
+# endif
+#endif
+!
+!=======================================================================
+!  Read in forcing data from FORCING NetCDF file(s).
+!=======================================================================
+!
+!  Set switch to process surface atmospheric fields.
+!
+#if defined FOUR_DVAR   && \
+    defined BULK_FLUXES && defined PRIOR_BULK_FLUXES
+!  In 4D-Var data assimilation applications, the user have the option
+!  to fix the prior (background phase) surface fluxes in the successive
+!  outer loops (Nouter>1) or the final analysis phase. In such case, the
+!  fluxes are read from the background trajector
+!
+      IF (Nrun.eq.1) THEN
+        Lprocess=.TRUE.
+      ELSE
+        Lprocess=.FALSE.
+      END IF
+#else
+      Lprocess=.TRUE.
+#endif
+
+#if !(defined ANA_WINDS   || defined FRC_COUPLING) && \
+     (defined BULK_FLUXES || defined ECOSIM)
+!
+!  Surface wind components.
+!
+      IF (Lprocess) THEN
+        CALL get_2dfld (ng, iNLM, idUair, ncFRCid(idUair,ng),           &
+     &                  nFfiles(ng), FRC(1,ng), update(1),              &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+# ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+# endif
+     &                  FORCES(ng) % UwindG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+!
+        CALL get_2dfld (ng , iNLM, idVair, ncFRCid(idVair,ng),          &
+     &                  nFfiles(ng), FRC(1,ng), update(1),              &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+# ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+# endif
+     &                  FORCES(ng) % VwindG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+#endif
+
+#if defined READ_STRESS || \
+    !(defined ANA_SMFLUX || defined FRC_COUPLING || defined BULK_FLUXES) 
+    
+!
+!  Surface wind stress components.
+!
+      IF (Lprocess) THEN
+        CALL get_2dfld (ng, iNLM, idUsms, ncFRCid(idUsms,ng),           &
+     &                  nFfiles(ng), FRC(1,ng), update(1),              &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+# ifdef MASKING
+     &                  GRID(ng) % umask,                               &
+# endif
+     &                  FORCES(ng) % sustrG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+!
+        CALL get_2dfld (ng, iNLM, idVsms, ncFRCid(idVsms,ng),           &
+     &                  nFfiles(ng), FRC(1,ng), update(1),              &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+# ifdef MASKING
+     &                  GRID(ng) % vmask,                               &
+# endif
+     &                  FORCES(ng) % svstrG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+#endif
+
+#if !(defined ANA_PAIR    || defined FRC_COUPLING) && \
+     (defined BULK_FLUXES || defined ECOSIM        || defined ATM_PRESS)
+!
+!  Surface air pressure.
+!
+      IF (Lprocess) THEN
+        CALL get_2dfld (ng, iNLM, idPair, ncFRCid(idPair,ng),           &
+     &                  nFfiles(ng), FRC(1,ng), update(1),              &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+# ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+# endif
+     &                  FORCES(ng) % PairG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+#endif
+
+#if !defined ANA_WWAVE && defined WAVE_DATA
+!
+!  Surface wind induced wave properties.
+!
+# ifdef WAVES_DIR
+      CALL get_2dfld (ng, iNLM, idWdir, ncFRCid(idWdir,ng),             &
+     &                nFfiles(ng), FRC(1,ng), update(1),                &
+     &                LBi, UBi, LBj, UBj, 2, 1,                         &
+#  ifdef MASKING
+     &                GRID(ng) % rmask,                                 &
+#  endif
+     &                FORCES(ng) % DwaveG)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+# endif
+
+# ifdef WAVES_HEIGHT
+!
+      CALL get_2dfld (ng, iNLM, idWamp, ncFRCid(idWamp,ng),             &
+     &                nFfiles(ng), FRC(1,ng), update(1),                &
+     &                LBi, UBi, LBj, UBj, 2, 1,                         &
+#  ifdef MASKING
+     &                GRID(ng) % rmask,                                 &
+#  endif
+     &                FORCES(ng) % HwaveG)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+# endif
+
+# ifdef WAVES_LENGTH
+!
+      CALL get_2dfld (ng, iNLM, idWlen, ncFRCid(idWlen,ng),             &
+     &                nFfiles(ng), FRC(1,ng), update(1),                &
+     &                LBi, UBi, LBj, UBj, 2, 1,                         &
+#  ifdef MASKING
+     &                GRID(ng) % rmask,                                 &
+#  endif
+     &                FORCES(ng) % LwaveG)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+# endif
+
+# ifdef WAVES_TOP_PERIOD
+!
+      CALL get_2dfld (ng, iNLM, idWptp, ncFRCid(idWptp,ng),             &
+     &                nFfiles(ng), FRC(1,ng), update(1),                &
+     &                LBi, UBi, LBj, UBj, 2, 1,                         &
+#  ifdef MASKING
+     &                GRID(ng) % rmask,                                 &
+#  endif
+     &                FORCES(ng) % Pwave_topG)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+# endif
+
+# ifdef WAVES_BOT_PERIOD
+!
+      CALL get_2dfld (ng, iNLM, idWpbt, ncFRCid(idWpbt,ng),             &
+     &                nFfiles(ng), FRC(1,ng), update(1),                &
+     &                LBi, UBi, LBj, UBj, 2, 1,                         &
+#  ifdef MASKING
+     &                GRID(ng) % rmask,                                 &
+#  endif
+     &                FORCES(ng) % Pwave_botG(:,:,1))
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+# endif
+
+# if defined WAVES_UB
+!
+      CALL get_2dfld (ng, iNLM, idWorb, ncFRCid(idWorb,ng),             &
+     &                nFfiles(ng), FRC(1,ng), update(1),                &
+     &                LBi, UBi, LBj, UBj, 2, 1,                         &
+#  ifdef MASKING
+     &                GRID(ng) % rmask,                                 &
+#  endif
+     &                FORCES(ng) % Ub_swanG)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+# endif
+
+# if defined TKE_WAVEDISS
+!
+      CALL get_2dfld (ng, iNLM, idWdis, ncFRCid(idWdis,ng),             &
+     &                nFfiles(ng), FRC(1,ng), update(1),                &
+     &                LBi, UBi, LBj, UBj, 2, 1,                         &
+#  ifdef MASKING
+     &                GRID(ng) % rmask,                                 &
+#  endif
+     &                FORCES(ng) % Wave_dissipG(:,:,1))
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+# endif
+
+# if defined SVENDSEN_ROLLER
+!
+      CALL get_2dfld (ng, iNLM, idWbrk, ncFRCid(idWbrk,ng),             &
+     &                nFfiles(ng), FRC(1,ng), update(1),                &
+     &                LBi, UBi, LBj, UBj, 2, 1,                         &
+#  ifdef MASKING
+     &                GRID(ng) % rmask,                                 &
+#  endif
+     &                FORCES(ng) % Wave_breakG)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+# endif
+#endif
+
+#ifdef SOLVE3D
+
+# if !(defined ANA_CLOUD || defined FRC_COUPLING) && defined CLOUDS
+!
+!  Cloud fraction.
+!
+      CALL get_2dfld (ng, iNLM, idCfra, ncFRCid(idCfra,ng),             &
+     &                nFfiles(ng), FRC(1,ng), update(1),                &
+     &                LBi, UBi, LBj, UBj, 2, 1,                         &
+#  ifdef MASKING
+     &                GRID(ng) % rmask,                                 &
+#  endif
+     &                FORCES(ng) % cloudG)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+# endif
+
+# if !(defined ANA_SRFLUX || defined FRC_COUPLING) && defined SHORTWAVE
+!
+!  Surface solar shortwave radiation.
+!
+      IF (Lprocess) THEN
+        CALL get_2dfld (ng, iNLM, idSrad, ncFRCid(idSrad,ng),           &
+     &                  nFfiles(ng), FRC(1,ng), update(1),              &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+#  ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+#  endif
+     &                  FORCES(ng) % srflxG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+# endif
+
+# if defined RED_TIDE && defined DAILY_SHORTWAVE
+!
+!  Daily-averaged Surface solar shortwave radiation.
+!
+      CALL get_2dfld (ng, iNLM, idAsrf, ncFRCid(idAsrf,ng),             &
+     &                nFfiles(ng), FRC(1,ng), update(1),                &
+     &                LBi, UBi, LBj, UBj, 2, 1,                         &
+#  ifdef MASKING
+     &                GRID(ng) % rmask,                                 &
+#  endif
+     &                FORCES(ng) % srflxG_avg)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+# endif
+
+# if defined BULK_FLUXES  && \
+   !(defined FRC_COUPLING || defined LONGWAVE || defined LONGWAVE_OUT)
+!
+!  Surface net longwave radiation.
+!
+      IF (Lprocess) THEN
+        CALL get_2dfld (ng, iNLM, idLrad, ncFRCid(idLrad,ng),           &
+     &                  nFfiles(ng), FRC(1,ng), update(1),              &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+#  ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+#  endif
+     &                  FORCES(ng) % lrflxG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+# endif
+
+# if defined BULK_FLUXES  && defined LONGWAVE_OUT && \
+    !defined FRC_COUPLING
+!
+!  Surface downwelling longwave radiation.
+!
+      IF (Lprocess) THEN
+        CALL get_2dfld (ng, iNLM, idLdwn, ncFRCid(idLdwn,ng),           &
+     &                  nFfiles(ng), FRC(1,ng), update(1),              &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+#  ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+#  endif
+     &                  FORCES(ng) % lrflxG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+# endif
+
+# if !(defined ANA_TAIR   || defined FRC_COUPLING) && \
+    ( defined BULK_FLUXES || defined ECOSIM        || \
+     (defined SHORTWAVE   && defined ANA_SRFLUX    && defined ALBEDO) )
+!
+!  Surface air temperature.
+!
+      IF (Lprocess) THEN
+        CALL get_2dfld (ng, iNLM, idTair, ncFRCid(idTair,ng),           &
+     &                  nFfiles(ng), FRC(1,ng), update(1),              &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+#  ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+#  endif
+     &                  FORCES(ng) % TairG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+# endif
+
+# if !(defined ANA_HUMIDITY || defined FRC_COUPLING) && \
+      (defined BULK_FLUXES  || defined ECOSIM)
+!
+!  Surface air humidity.
+!
+      IF (Lprocess) THEN
+        CALL get_2dfld (ng, iNLM, idQair, ncFRCid(idQair,ng),           &
+     &                  nFfiles(ng), FRC(1,ng), update(1),              &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+#  ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+#  endif
+     &                  FORCES(ng) % HairG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+# endif
+
+# if !(defined ANA_RAIN || defined FRC_COUPLING) && defined BULK_FLUXES
+!
+!  Rain fall rate.
+!
+      IF (Lprocess) THEN
+        CALL get_2dfld (ng, iNLM, idrain, ncFRCid(idrain,ng),           &
+     &                  nFfiles(ng), FRC(1,ng), update(1),              &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+#  ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+#  endif
+     &                  FORCES(ng) % rainG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+# endif
+
+# if !(defined ANA_STFLUX || defined FRC_COUPLING || \
+       defined BULK_FLUXES)
+!
+!  Surface net heat flux.
+!
+      IF (Lprocess) THEN
+        CALL get_2dfld (ng, iNLM, idTsur(itemp),                        &
+     &                  ncFRCid(idTsur(itemp),ng),                      &
+     &                  nFfiles(ng), FRC(1,ng), update(1),              &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+#  ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+#  endif
+     &                  FORCES(ng) % stfluxG(:,:,:,itemp))
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+# endif
+
+# if !defined ANA_SST && defined QCORRECTION
+!
+!  Surface net heat flux correction fields: sea surface temperature
+!  (SST).
+!
+      CALL get_2dfld (ng, iNLM, idSSTc, ncFRCid(idSSTc,ng),             &
+     &                nFfiles(ng), FRC(1,ng), update(1),                &
+     &                LBi, UBi, LBj, UBj, 2, 1,                         &
+#  ifdef MASKING
+     &                GRID(ng) % rmask,                                 &
+#  endif
+     &                FORCES(ng) % sstG)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+# endif
+
+# if !defined ANA_DQDSST && defined QCORRECTION
+!
+!  Surface net heat flux correction fields: heat flux sensitivity to
+!  SST (dQdSST).
+!
+      CALL get_2dfld (ng, iNLM, iddQdT, ncFRCid(iddQdT,ng),             &
+     &                nFfiles(ng), FRC(1,ng), update(1),                &
+     &                LBi, UBi, LBj, UBj, 2, 1,                         &
+#  ifdef MASKING
+     &                GRID(ng) % rmask,                                 &
+#  endif
+     &                FORCES(ng) % dqdtG)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+# endif
+
+# ifndef ANA_BTFLUX
+!
+!  Bottom net heat flux.
+!
+      CALL get_2dfld (ng, iNLM, idTbot(itemp),                          &
+     &                ncFRCid(idTbot(itemp),ng),                        &
+     &                nFfiles(ng), FRC(1,ng), update(1),                &
+     &                LBi, UBi, LBj, UBj, 2, 1,                         &
+#  ifdef MASKING
+     &                GRID(ng) % rmask,                                 &
+#  endif
+     &                FORCES(ng) % btfluxG(:,:,:,itemp))
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+# endif
+
+# if !defined ANA_SSFLUX     && defined SALINITY
+#  if !(defined BULK_FLUXES  || defined EMINUSP     || \
+        defined FRC_COUPLING)
+!
+!  Surface net freshwater flux: E-P from NetCDF variable "swflux".
+!
+      IF (Lprocess) THEN
+        CALL get_2dfld (ng, iNLM, idsfwf, ncFRCid(idsfwf,ng),           &
+     &                  nFfiles(ng), FRC(1,ng), update(1),              &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+#   ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+#   endif
+     &                  FORCES(ng) % stfluxG(:,:,:,isalt))
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+
+#  elif defined BULK_FLUXES  && !defined EMINUSP
+!
+!  Surface net freshwater flux (E-P) from NetCDF variable "EminusP".
+!
+      IF (Lprocess) THEN
+        CALL get_2dfld (ng, iNLM, idEmPf, ncFRCid(idEMPf,ng),           &
+     &                  nFfiles(ng), FRC(1,ng), update(1),              &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+#   ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+#   endif
+     &                  FORCES(ng) % stfluxG(:,:,:,isalt))
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+#  endif
+
+#  if !defined ANA_SSS && (defined SCORRECTION || defined SRELAXATION)
+!
+!  Surface net freshwater flux correction field: sea surface salinity.
+!
+      CALL get_2dfld (ng, iNLM, idSSSc, ncFRCid(idSSSc,ng),             &
+     &                nFfiles(ng), FRC(1,ng), update(1),                &
+     &                LBi, UBi, LBj, UBj, 2, 1,                         &
+#   ifdef MASKING
+     &                GRID(ng) % rmask,                                 &
+#   endif
+     &                FORCES(ng) % sssG)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+#  endif
+
+#  ifndef ANA_BSFLUX
+!
+!  Bottom net freshwater flux.
+!
+      CALL get_2dfld (ng, iNLM, idTbot(isalt),                          &
+     &                ncFRCid(idTbot(isalt),ng),                        &
+     &                nFfiles(ng), FRC(1,ng), update(1),                &
+     &                LBi, UBi, LBj, UBj, 2, 1,                         &
+#   ifdef MASKING
+     &                GRID(ng) % rmask,                                 &
+#   endif
+     &                FORCES(ng) % btfluxG(:,:,:,isalt))
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+#  endif
+# endif
+
+# if defined BIOLOGY || defined SEDIMENT || defined T_PASSIVE
+#  ifndef ANA_SPFLUX
+!
+!  Passive tracers surface fluxes.
+!
+      DO i=NAT+1,NT(ng)
+        CALL get_2dfld (ng, iNLM, idTsur(i), ncFRCid(idTsur(i),ng),     &
+     &                  nFfiles(ng), FRC(1,ng), update(1),              &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+#   ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+#   endif
+     &                  FORCES(ng) % stfluxG(:,:,:,i))
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END DO
+#  endif
+
+#  ifndef ANA_BPFLUX
+!
+!  Passive tracers bottom fluxes.
+!
+      DO i=NAT+1,NT(ng)
+        CALL get_2dfld (ng, iNLM, idTbot(i), ncFRCid(idTbot(i),ng),     &
+     &                  nFfiles(ng), FRC(1,ng), update(1),              &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+#   ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+#   endif
+     &                  FORCES(ng) % btfluxG(:,:,:,i))
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END DO
+#  endif
+# endif
+#endif
+
+#if !defined ANA_RESPIRATION && defined HYPOXIA_SRM
+!
+!  Total respiration rate for hypoxia.
+!
+      CALL get_3dfld (ng, iNLM, idResR, ncFRCid(idResR,ng),             &
+     &                nFfiles(ng), FRC(1,ng), update(1),                &
+     &                LBi, UBi, LBj, UBj, 1, N(ng), 2, 1,               &
+#  ifdef MASKING
+     &                GRID(ng) % rmask,                                 &
+#  endif
+     &                OCEAN(ng) % respirationG)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+#endif
+
+#ifdef RED_TIDE
+!
+!  Red tide Observed Dissolved Inorganic Nutrient.
+!
+      CALL get_3dfld (ng, iNLM, idODIN, ncFRCid(idODIN,ng),             &
+     &                nFfiles(ng), FRC(1,ng), update(1),                &
+     &                LBi, UBi, LBj, UBj, 1, N(ng), 2, 1,               &
+#  ifdef MASKING
+     &                GRID(ng) % rmask,                                 &
+#  endif
+     &                OCEAN(ng) % DIN_obsG)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+#endif
+
+#if defined FOUR_DVAR   && \
+    defined BULK_FLUXES && defined PRIOR_BULK_FLUXES
+!
+!=======================================================================
+!  In 4D-Var data assimilation algorithms, the user has the option to
+!  impose the prior (background phase) surface fluxes in the successive
+!  outer loops (Nouter>1) or the final analysis phase. Such fluxes were
+!  computed by routine "bulk_fluxes" and stored in the NLM background
+!  trajectory, BLK structure. Notice that "bulk_fluxes" is called in
+!  "main3d" only during the prior trajectory computation.
+!
+!  The strategy is to save the 2D surface fluxes in the quicksave
+!  NetCDF  file to allow frequent data records to resolve the daily
+!  cycle while maintaining its size small.
+!=======================================================================
+!
+      IF (.not.Lprocess) THEN
+!
+!  Get prior surface wind stress components.
+!
+        CALL get_2dfld (ng, iNLM, idUsms, BLK(ng)%ncid,                 &
+     &                  1, BLK(ng), update(1),                          &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+# ifdef MASKING
+     &                  GRID(ng) % umask,                               &
+# endif
+     &                  FORCES(ng) % sustrG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+!
+        CALL get_2dfld (ng, iNLM, idVsms, BLK(ng)%ncid,                 &
+     &                  1, BLK(ng), update(1),                          &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+# ifdef MASKING
+     &                  GRID(ng) % vmask,                               &
+# endif
+     &                  FORCES(ng) % svstrG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+
+# ifdef ATM_PRESS
+!
+!  Get prior surface air pressure.
+!
+        CALL get_2dfld (ng, iNLM, idPair, BLK(ng)%ncid,                 &
+     &                  1, BLK(ng), update(1),                          &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+#  ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+#  endif
+     &                  FORCES(ng) % PairG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+# endif
+
+# ifdef SOLVE3D
+#  ifdef SHORTWAVE
+!
+!  Get prior shortwave radiation flux.  For consistency, we need to
+!  process the same values using in the computation of the net heat
+!  flux since there is a time interpolation from snapshots.
+!
+        CALL get_2dfld (ng, iNLM, idSrad, BLK(ng)%ncid,                 &
+     &                  1, BLK(ng), update(1),                          &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+#   ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+#   endif
+     &                  FORCES(ng) % srflxG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+#  endif
+!
+!  Get prior surface net heat flux.
+!
+        CALL get_2dfld (ng, iNLM, idTsur(itemp), BLK(ng)%ncid,          &
+     &                  1, BLK(ng), update(1),                          &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+#  ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+#  endif
+     &                  FORCES(ng) % stfluxG(:,:,:,itemp))
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+
+#  ifdef SALINITY
+!
+!  Get prior net freshwater flux (E-P). The kinematic net freshwater
+!  will be computed in "set_vbc" by multiplying with surface salinity.
+!
+        CALL get_2dfld (ng, iNLM, idEmPf, BLK(ng)%ncid,                 &
+     &                  1, BLK(ng), update(1),                          &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+#   ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+#   endif
+     &                  FORCES(ng) % stfluxG(:,:,:,isalt))
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+#  endif
+# endif
+      END IF
+#endif
+!
+!=======================================================================
+!  Read in open boundary conditions from BOUNDARY NetCDF file.
+!=======================================================================
+
+#ifndef ANA_FSOBC
+!
+!  Free-surface open boundary conditions.
+!
+      IF (LprocessOBC(ng)) THEN
+        IF (LBC(iwest,isFsur,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idZbry(iwest),                      &
+     &                    ncBRYid(idZbry(iwest),ng),                    &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    JLB, JUB, 1, 2, 0, Mm(ng)+1, 1,               &
+     &                    BOUNDARY(ng) % zetaG_west)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+!
+        IF (LBC(ieast,isFsur,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idZbry(ieast),                      &
+     &                    ncBRYid(idZbry(ieast),ng),                    &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    JLB, JUB, 1, 2, 0, Mm(ng)+1, 1,               &
+     &                    BOUNDARY(ng) % zetaG_east)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+!
+        IF (LBC(isouth,isFsur,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idZbry(isouth),                     &
+     &                    ncBRYid(idZbry(isouth),ng),                   &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    ILB, IUB, 1, 2, 0, Lm(ng)+1, 1,               &
+     &                    BOUNDARY(ng) % zetaG_south)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+!
+        IF (LBC(inorth,isFsur,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idZbry(inorth),                     &
+     &                    ncBRYid(idZbry(inorth),ng),                   &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    ILB, IUB, 1, 2, 0, Lm(ng)+1, 1,               &
+     &                    BOUNDARY(ng) % zetaG_north)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+      END IF
+#endif
+
+#ifndef ANA_M2OBC
+!
+!  2D momentum components open boundary conditions.
+!
+      IF (LprocessOBC(ng)) THEN
+        IF (LBC(iwest,isUbar,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idU2bc(iwest),                      &
+     &                    ncBRYid(idU2bc(iwest),ng),                    &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    JLB, JUB, 1, 2, 0, Mm(ng)+1, 1,               &
+     &                    BOUNDARY(ng) % ubarG_west)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+!
+        IF (LBC(iwest,isVbar,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idV2bc(iwest),                      &
+     &                    ncBRYid(idV2bc(iwest),ng),                    &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    JLB, JUB, 1, 2, 1, Mm(ng)+1, 1,               &
+     &                    BOUNDARY(ng) % vbarG_west)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+!
+        IF (LBC(ieast,isUbar,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idU2bc(ieast),                      &
+     &                    ncBRYid(idU2bc(ieast),ng),                    &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    JLB, JUB, 1, 2, 0, Mm(ng)+1, 1,               &
+     &                    BOUNDARY(ng) % ubarG_east)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+!
+        IF (LBC(ieast,isVbar,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idV2bc(ieast),                      &
+     &                    ncBRYid(idV2bc(ieast),ng),                    &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    JLB, JUB, 1, 2, 1, Mm(ng)+1, 1,               &
+     &                    BOUNDARY(ng) % vbarG_east)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+!
+        IF (LBC(isouth,isUbar,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idU2bc(isouth),                     &
+     &                    ncBRYid(idU2bc(isouth),ng),                   &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    ILB, IUB, 1, 2, 1, Lm(ng)+1, 1,               &
+     &                    BOUNDARY(ng) % ubarG_south)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+!
+        IF (LBC(isouth,isVbar,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idV2bc(isouth),                     &
+     &                    ncBRYid(idV2bc(isouth),ng),                   &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    ILB, IUB, 1, 2, 0, Lm(ng)+1, 1,               &
+     &                    BOUNDARY(ng) % vbarG_south)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+!
+        IF (LBC(inorth,isUbar,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idU2bc(inorth),                     &
+     &                    ncBRYid(idU2bc(inorth),ng),                   &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    ILB, IUB, 1, 2, 1, Lm(ng)+1, 1,               &
+     &                    BOUNDARY(ng) % ubarG_north)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+!
+        IF (LBC(inorth,isVbar,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idV2bc(inorth),                     &
+     &                    ncBRYid(idV2bc(inorth),ng),                   &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    ILB, IUB, 1, 2, 0, Lm(ng)+1, 1,               &
+     &                    BOUNDARY(ng) % vbarG_north)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+      END IF
+#endif
+
+#ifdef SOLVE3D
+# ifndef ANA_M3OBC
+!
+!  3D momentum components open boundary conditions.
+!
+      IF (LprocessOBC(ng)) THEN
+        IF (LBC(iwest,isUvel,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idU3bc(iwest),                      &
+     &                    ncBRYid(idU3bc(iwest),ng),                    &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    JLB, JUB, N(ng), 2, 0, Mm(ng)+1, N(ng),       &
+     &                    BOUNDARY(ng) % uG_west)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+!
+        IF (LBC(iwest,isVvel,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idV3bc(iwest),                      &
+     &                    ncBRYid(idV3bc(iwest),ng),                    &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    JLB, JUB, N(ng), 2, 1, Mm(ng)+1, N(ng),       &
+     &                    BOUNDARY(ng) % vG_west)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+!
+        IF (LBC(ieast,isUvel,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idU3bc(ieast),                      &
+     &                    ncBRYid(idU3bc(ieast),ng),                    &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    JLB, JUB, N(ng), 2, 0, Mm(ng)+1, N(ng),       &
+     &                    BOUNDARY(ng) % uG_east)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+!
+        IF (LBC(ieast,isVvel,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idV3bc(ieast),                      &
+     &                    ncBRYid(idV3bc(ieast),ng),                    &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    JLB, JUB, N(ng), 2, 1, Mm(ng)+1, N(ng),       &
+     &                    BOUNDARY(ng) % vG_east)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+!
+        IF (LBC(isouth,isUvel,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idU3bc(isouth),                     &
+     &                    ncBRYid(idU3bc(isouth),ng),                   &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    ILB, IUB, N(ng), 2, 1, Lm(ng)+1, N(ng),       &
+     &                    BOUNDARY(ng) % uG_south)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+!
+        IF (LBC(isouth,isVvel,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idV3bc(isouth),                     &
+     &                    ncBRYid(idV3bc(isouth),ng),                   &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    ILB, IUB, N(ng), 2, 0, Lm(ng)+1, N(ng),       &
+     &                    BOUNDARY(ng) % vG_south)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+!
+        IF (LBC(inorth,isUvel,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idU3bc(inorth),                     &
+     &                    ncBRYid(idU3bc(inorth),ng),                   &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    ILB, IUB, N(ng), 2, 1, Lm(ng)+1, N(ng),       &
+     &                    BOUNDARY(ng) % uG_north)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+!
+        IF (LBC(inorth,isVvel,ng)%acquire) THEN
+          CALL get_ngfld (ng, iNLM, idV3bc(inorth),                     &
+     &                    ncBRYid(idV3bc(inorth),ng),                   &
+     &                    nBCfiles(ng), BRY(1,ng), update(1),           &
+     &                    ILB, IUB, N(ng), 2, 0, Lm(ng)+1, N(ng),       &
+     &                    BOUNDARY(ng) % vG_north)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+      END IF
+# endif
+
+# ifndef ANA_TOBC
+!
+!  Tracer variables open boundary conditions.
+!
+      IF (LprocessOBC(ng)) THEN
+        DO i=1,NT(ng)
+          IF (LBC(iwest,isTvar(i),ng)%acquire) THEN
+            CALL get_ngfld (ng, iNLM, idTbry(iwest,i),                  &
+     &                      ncBRYid(idTbry(iwest,i),ng),                &
+     &                      nBCfiles(ng), BRY(1,ng), update(1),         &
+     &                      JLB, JUB, N(ng), 2, 0, Mm(ng)+1, N(ng),     &
+     &                      BOUNDARY(ng) % tG_west(:,:,:,i))
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+        END DO
+!
+        DO i=1,NT(ng)
+          IF (LBC(ieast,isTvar(i),ng)%acquire) THEN
+            CALL get_ngfld (ng, iNLM, idTbry(ieast,i),                  &
+     &                      ncBRYid(idTbry(ieast,i),ng),                &
+     &                      nBCfiles(ng), BRY(1,ng), update(1),         &
+     &                      JLB, JUB, N(ng), 2, 0, Mm(ng)+1, N(ng),     &
+     &                      BOUNDARY(ng) % tG_east(:,:,:,i))
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+        END DO
+!
+        DO i=1,NT(ng)
+          IF (LBC(isouth,isTvar(i),ng)%acquire) THEN
+            CALL get_ngfld (ng, iNLM, idTbry(isouth,i),                 &
+     &                      ncBRYid(idTbry(isouth,i),ng),               &
+     &                      nBCfiles(ng), BRY(1,ng), update(1),         &
+     &                      ILB, IUB, N(ng), 2, 0, Lm(ng)+1, N(ng),     &
+     &                      BOUNDARY(ng) % tG_south(:,:,:,i))
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+        END DO
+!
+        DO i=1,NT(ng)
+          IF (LBC(inorth,isTvar(i),ng)%acquire) THEN
+            CALL get_ngfld (ng, iNLM, idTbry(inorth,i),                 &
+     &                      ncBRYid(idTbry(inorth,i),ng),               &
+     &                      nBCfiles(ng), BRY(1,ng), update(1),         &
+     &                      ILB, IUB, N(ng), 2, 0, Lm(ng)+1, N(ng),     &
+     &                      BOUNDARY(ng) % tG_north(:,:,:,i))
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+        END DO
+      END IF
+# endif
+#endif
+!
+!=======================================================================
+!  Read in data from Climatology NetCDF file.
+!=======================================================================
+
+#ifndef ANA_SSH
+!
+!  Free-surface climatology.
+!
+      IF (LsshCLM(ng)) THEN
+        CALL get_2dfld (ng, iNLM, idSSHc, ncCLMid(idSSHc,ng),           &
+     &                  nCLMfiles(ng), CLM(1,ng), update(1),            &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+# ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+# endif
+     &                  CLIMA(ng) % sshG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+#endif
+#ifndef ANA_M2CLIMA
+!
+!  2D momentum components climatology.
+!
+      IF (Lm2CLM(ng)) THEN
+        CALL get_2dfld (ng, iNLM, idUbcl, ncCLMid(idUbcl,ng),           &
+     &                  nCLMfiles(ng), CLM(1,ng), update(1),            &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+# ifdef MASKING
+     &                  GRID(ng) % umask,                               &
+# endif
+     &                  CLIMA(ng) % ubarclmG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+!
+        CALL get_2dfld (ng, iNLM, idVbcl, ncCLMid(idVbcl,ng),           &
+     &                  nCLMfiles(ng), CLM(1,ng), update(1),            &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+# ifdef MASKING
+     &                  GRID(ng) % vmask,                               &
+# endif
+     &                  CLIMA(ng) % vbarclmG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+#endif
+#ifdef SOLVE3D
+# ifndef ANA_M3CLIMA
+!
+!  3D momentum components climatology.
+!
+      IF (Lm3CLM(ng)) THEN
+        CALL get_3dfld (ng, iNLM, idUclm, ncCLMid(idUclm,ng),           &
+     &                  nCLMfiles(ng), CLM(1,ng), update(1),            &
+     &                  LBi, UBi, LBj, UBj, 1, N(ng), 2, 1,             &
+#  ifdef MASKING
+     &                  GRID(ng) % umask,                               &
+#  endif
+     &                  CLIMA(ng) % uclmG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+!
+        CALL get_3dfld (ng, iNLM, idVclm, ncCLMid(idVclm,ng),           &
+     &                  nCLMfiles(ng), CLM(1,ng), update(1),            &
+     &                  LBi, UBi, LBj, UBj, 1, N(ng), 2, 1,             &
+#  ifdef MASKING
+     &                  GRID(ng) % vmask,                               &
+#  endif
+     &                  CLIMA(ng) % vclmG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+# endif
+# ifndef ANA_TCLIMA
+!
+!  Tracers variables climatology.
+!
+      ic=0
+      DO i=1,NT(ng)
+        IF (LtracerCLM(i,ng)) THEN
+          ic=ic+1
+          CALL get_3dfld (ng, iNLM, idTclm(i),                          &
+     &                    ncCLMid(idTclm(i),ng),                        &
+     &                    nCLMfiles(ng), CLM(1,ng), update(1),          &
+     &                    LBi, UBi, LBj, UBj, 1, N(ng), 2, 1,           &
+#  ifdef MASKING
+     &                    GRID(ng) % rmask,                             &
+#  endif
+     &                    CLIMA(ng) % tclmG(:,:,:,:,ic))
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+      END DO
+# endif
+#endif
+
+#ifdef TLM_CHECK
+!
+!=======================================================================
+!  If tangent linear model check, read in nonlinear forward solution
+!  to compute dot product with perturbated nonlinear solution. Time
+!  interpolation between snapshot is not required (see subroutine
+!  "nl_dotproduct").
+!=======================================================================
+!
+      IF (outer.ge.1) THEN
+!
+!  Read in free-surface.
+!
+        CALL get_2dfld (ng, iNLM, idFsur, FWD(ng)%ncid,                 &
+     &                  1, FWD(ng), update(1),                          &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+# ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+# endif
+     &                  OCEAN(ng) % zetaG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+!
+!  Read 2D momentum.
+!
+        CALL get_2dfld (ng, iNLM, idUbar, FWD(ng)%ncid,                 &
+     &                  1, FWD(ng), update(1),                          &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+# ifdef MASKING
+     &                  GRID(ng) % umask,                               &
+# endif
+     &                  OCEAN(ng) % ubarG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+
+        CALL get_2dfld (ng, iNLM, idVbar, FWD(ng)%ncid,                 &
+     &                  1, FWD(ng), update(1),                          &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+# ifdef MASKING
+     &                  GRID(ng) % vmask,                               &
+# endif
+     &                  OCEAN(ng) % vbarG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+# ifdef SOLVE3D
+!
+!  Read in 3D momentum.
+!
+        CALL get_3dfld (ng, iNLM, idUvel, FWD(ng)%ncid,                 &
+     &                  1, FWD(ng), update(1),                          &
+     &                  LBi, UBi, LBj, UBj, 1, N(ng), 2, 1,             &
+#  ifdef MASKING
+     &                  GRID(ng) % umask,                               &
+#  endif
+     &                  OCEAN(ng) % uG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+
+        CALL get_3dfld (ng, iNLM, idVvel, FWD(ng)%ncid,                 &
+     &                  1, FWD(ng), update(1),                          &
+     &                  LBi, UBi, LBj, UBj, 1, N(ng), 2, 1,             &
+#  ifdef MASKING
+     &                  GRID(ng) % vmask,                               &
+#  endif
+     &                  OCEAN(ng) % vG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+!
+!  Read in 3D tracers.
+!
+        DO i=1,NT(ng)
+          CALL get_3dfld (ng, iNLM, idTvar(i), FWD(ng)%ncid,            &
+     &                    1, FWD(ng), update(1),                        &
+     &                    LBi, UBi, LBj, UBj, 1, N(ng), 2, 1,           &
+#  ifdef MASKING
+     &                    GRID(ng) % rmask,                             &
+#  endif
+     &                    OCEAN(ng) % tG(:,:,:,:,i))
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END DO
+# endif
+      END IF
+#endif
+
+#if defined NLM_OUTER                || \
+    defined RBL4DVAR                 || \
+    defined RBL4DVAR_ANA_SENSITIVITY || \
+    defined RBL4DVAR_FCT_SENSITIVITY || \
+    defined SP4DVAR                  || \
+    defined TL_RBL4DVAR
+!
+!=======================================================================
+!  Read weak contraint forcing snapshots. Notice that the forward
+!  basic state snapshops arrays are reused here.
+!=======================================================================
+!
+      IF (FrequentImpulse(ng)) THEN
+!
+!  Read in free-surface.
+!
+        CALL get_2dfld (ng, iNLM, idFsur, TLF(ng)%ncid,                 &
+     &                  1, TLF(ng), update(1),                          &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+# ifdef MASKING
+     &                  GRID(ng) % rmask,                               &
+# endif
+     &                  OCEAN(ng) % zetaG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+
+# ifndef SOLVE3D
+!
+!  Read 2D momentum.
+!
+        CALL get_2dfld (ng, iNLM, idUbar, TLF(ng)%ncid,                 &
+     &                  1, TLF(ng), update(1),                          &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+#  ifdef MASKING
+     &                  GRID(ng) % umask,                               &
+#  endif
+     &                  OCEAN(ng) % ubarG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+
+        CALL get_2dfld (ng, iNLM, idVbar, TLF(ng)%ncid,                 &
+     &                  1, TLF(ng), update(1),                          &
+     &                  LBi, UBi, LBj, UBj, 2, 1,                       &
+#  ifdef MASKING
+     &                  GRID(ng) % vmask,                               &
+#  endif
+     &                  OCEAN(ng) % vbarG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+# else
+!
+!  Read in 3D momentum.
+!
+        CALL get_3dfld (ng, iNLM, idUvel, TLF(ng)%ncid,                 &
+     &                  1, TLF(ng), update(1),                          &
+     &                  LBi, UBi, LBj, UBj, 1, N(ng), 2, 1,             &
+#  ifdef MASKING
+     &                  GRID(ng) % umask,                               &
+#  endif
+     &                  OCEAN(ng) % uG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+
+        CALL get_3dfld (ng, iNLM, idVvel, TLF(ng)%ncid,                 &
+     &                  1, TLF(ng), update(1),                          &
+     &                  LBi, UBi, LBj, UBj, 1, N(ng), 2, 1,             &
+#  ifdef MASKING
+     &                  GRID(ng) % vmask,                               &
+#  endif
+     &                  OCEAN(ng) % vG)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+!
+!  Read in 3D tracers.
+!
+        DO i=1,NT(ng)
+          CALL get_3dfld (ng, iNLM, idTvar(i), TLF(ng)%ncid,            &
+     &                    1, TLF(ng), update(1),                        &
+     &                    LBi, UBi, LBj, UBj, 1, N(ng), 2, 1,           &
+#  ifdef MASKING
+     &                    GRID(ng) % rmask,                             &
+#  endif
+     &                    OCEAN(ng) % tG(:,:,:,:,i))
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END DO
+# endif
+      END IF
+#endif
+
+#ifdef PROFILE
+!
+!-----------------------------------------------------------------------
+!  Turn off input data time wall clock.
+!-----------------------------------------------------------------------
+!
+      CALL wclock_off (ng, iNLM, 3, __LINE__, __FILE__)
+#endif
+!
+      RETURN
+      END SUBROUTINE get_data

--- a/apps/common/modified_src/roms-trunk1041/mod_forces.F
+++ b/apps/common/modified_src/roms-trunk1041/mod_forces.F
@@ -1,0 +1,1366 @@
+#include "cppdefs.h"
+      MODULE mod_forces
+!
+!svn $Id: mod_forces.F 1039 2020-10-12 03:54:49Z arango $
+!================================================== Hernan G. Arango ===
+!  Copyright (c) 2002-2020 The ROMS/TOMS Group                         !
+!    Licensed under a MIT/X style license                              !
+!    See License_ROMS.txt                                              !
+!=======================================================================
+!                                                                      !
+!  Surface momentum stresses.                                          !
+!                                                                      !
+!  sustr        Surface momentum flux (wind stress) in the             !
+!                 XI-direction (m2/s2) at horizontal U-points.         !
+!  sustrG       Latest two-time snapshots of input "sustr" grided      !
+!                 data used for interpolation.                         !
+!  svstr        Surface momentum flux (wind stress) in the             !
+!                 ETA-direction (m2/s2) at horizontal V-points.        !
+!  svstrG       Latest two-time snapshots of input "svstr" grided      !
+!                 data used for interpolation.                         !
+!                                                                      !
+!  Bottom momentum stresses.                                           !
+!                                                                      !
+!  bustr        Bottom momentum flux (bottom stress) in the            !
+!                 XI-direction (m2/s2) at horizontal U-points.         !
+!  bvstr        Bottom momentum flux (bottom stress) in the            !
+!                 ETA-direction (m2/s2) at horizontal V-points.        !
+!                                                                      !
+!  Surface wind induced waves.                                         !
+!                                                                      !
+!  Hwave        Surface wind induced wave height (m).                  !
+!  HwaveG       Latest two-time snapshots of input "Hwave" grided      !
+!                 data used for interpolation.                         !
+!  Dwave        Surface wind induced wave direction (radians).         !
+!  DwaveG       Latest two-time snapshots of input "Dwave" grided      !
+!                 data used for interpolation.                         !
+!  Lwave        Mean surface wavelength read in from swan output       !
+!  LwaveG       Latest two-time snapshots of input "Lwave" grided      !
+!                 data used for interpolation.                         !
+!  Pwave_top    Wind induced surface wave period (s).                  !
+!  Pwave_topG   Latest two-time snapshots of input "Pwave_top" grided  !
+!                 data used for interpolation.                         !
+!  Pwave_bot    Wind induced bottom wave period (s).                   !
+!  Pwave_botG   Latest two-time snapshots of input "Pwave_bot" grided  !
+!                 data used for interpolation.                         !
+!  Ub_swan      Bottom orbital velocity read in from swan output       !
+!  Ub_swanG     Latest two-time snapshots of input "Ub_swan" grided    !
+!                 data used for interpolation.                         !
+!  wave_dissip  Wave dissipation                                       !
+!  wave_dissipG Latest two-time snapshots of input "wave_dissip"       !
+!                 gridded data used for interpolation.                 !
+!  Wave_break   Percent of wave breaking for use with roller model.    !
+!  Wave_breakG  Latest two-time snapshots of input "wave_break"        !
+!                 gridded data used for interpolation.                 !
+!                                                                      !
+!  Solar shortwave radiation flux.                                     !
+!                                                                      !
+!  srflx        Surface shortwave solar radiation flux (degC m/s)      !
+!                  at horizontal RHO-points                            !
+!  srflxG       Latest two-time snapshots of input "srflx" grided      !
+!                 data used for interpolation.                         !
+!                                                                      !
+!  Cloud fraction.                                                     !
+!                                                                      !
+!  cloud        Cloud fraction (percentage/100).                       !
+!  cloudG       Latest two-time snapshots of input "cloud" grided      !
+!                 data used for interpolation.                         !
+!                                                                      !
+!  Surface heat fluxes, Atmosphere-Ocean bulk parameterization.        !
+!                                                                      !
+!  lhflx        Latent heat flux (degC m/s).                           !
+!  lrflx        Longwave radiation (degC m/s).                         !
+!  shflx        Sensible heat flux (degC m/s).                         !
+!                                                                      !
+!  Surface air humidity.                                               !
+!                                                                      !
+!  Hair         Surface air specific (g/kg) or relative humidity       !
+!                 (percentage).                                        !
+!  HairG        Latest two-time snapshots of input "Hair" grided       !
+!                 data used for interpolation.                         !
+!                                                                      !
+!  Surface air pressure.                                               !
+!                                                                      !
+!  Pair         Surface air pressure (mb).                             !
+!  PairG        Latest two-time snapshots of input "Pair" grided       !
+!                 data used for interpolation.                         !
+!                                                                      !
+!  Surface air temperature.                                            !
+!                                                                      !
+!  Tair         Surface air temperature (Celsius)                      !
+!  TairG        Latest two-time snapshots of input "Tair" grided       !
+!                 data used for interpolation.                         !
+!  Surface Winds.                                                      !
+!                                                                      !
+!  Uwind        Surface wind in the XI-direction (m/s) at              !
+!                 horizontal RHO-points.                               !
+!  UwindG       Latest two-time snapshots of input "Uwind" grided      !
+!                 data used for interpolation.                         !
+!  Vwind        Surface wind in the ETA-direction (m/s) at             !
+!                 horizontal RHO-points.                               !
+!  VwindG       Latest two-time snapshots of input "Vwind" grided      !
+!                 data used for interpolation.                         !
+!                                                                      !
+!  Rain fall rate.                                                     !
+!                                                                      !
+!  evap         Evaporation rate (kg/m2/s).                            !
+!  rain         Rain fall rate (kg/m2/s).                              !
+!  rainG        Latest two-time snapshots of input "rain" grided       !
+!                 data used for interpolation.                         !
+!                                                                      !
+!  Surface tracer fluxes.                                              !
+!                                                                      !
+!  stflux       Forcing surface flux of tracer type variables from     !
+!                 data, coupling, bulk flux parameterization, or       !
+!                 analytical formulas.                                 !
+!                                                                      !
+!                 stflux(:,:,itemp)  surface net heat flux             !
+!                 stflux(:,:,isalt)  surface net freshwater flux (E-P) !
+!                                                                      !
+!  stfluxG      Latest two-time snapshots of input "stflux" grided     !
+!                 data used for interpolation.                         !
+!                                                                      !
+!  stflx        ROMS state surface flux of tracer type variables       !
+!                 (TracerUnits m/s) at horizontal RHO-points, as used  !
+!                 in the governing equations.                          !
+
+#if defined ADJUST_STFLUX && defined FOUR_DVAR
+!                                                                      !
+!  tflux        Surface tracer flux adjustments (:,:,Nfrec,2,itrc)     !
+#endif
+!                                                                      !
+!  Bottom tracer fluxes.                                               !
+!                                                                      !
+!  btflux       Forcing bottom flux of tracer type variables from      !
+!                 data or analytical formulas. Usually, the bottom     !
+!                 flux of tracer is zero.                              !
+!                                                                      !
+!                 btflux(:,:,itemp)  bottom heat flux                  !
+!                 btflux(:,:,isalt)  bottom freshwater flux            !
+!                                                                      !
+!  btfluxG      Latest two-time snapshots of input "vtflux" grided     !
+!                 data used for interpolation.                         !
+!                                                                      !
+!  btflx        ROMS state bottom flux of tracer type variables        !
+!                 (TracerUnits m/s) at horizontal RHO-points, as used  !
+!                 in the governing equations.                          !
+!                                                                      !
+!  Surface heat flux correction.                                       !
+!                                                                      !
+!  dqdt         Surface net heat flux sensitivity to SST,              !
+!                 d(Q)/d(SST), (m/s).                                  !
+!  dqdtG        Latest two-time snapshots of input "dqdt" grided       !
+!                 data used for interpolation.                         !
+!  sst          Sea surface temperature (Celsius).                     !
+!  sstG         Latest two-time snapshots of input "sst" grided        !
+!                 data used for interpolation.                         !
+!                                                                      !
+!  Surface freshwater flux correction.                                 !
+!                                                                      !
+!  sss          Sea surface salinity (PSU).                            !
+!  sssG         Latest two-time snapshots of input "sss" grided        !
+!                 data used for interpolation.                         !
+!                                                                      !
+!  Surface spectral downwelling irradiance.                            !
+!                                                                      !
+!  SpecIr       Spectral irradiance (NBands) from 400-700 nm at        !
+!                 5 nm bandwidth.                                      !
+!  avcos        Cosine of average zenith angle of downwelling          !
+!                 spectral photons.                                    !
+!                                                                      !
+!=======================================================================
+!
+        USE mod_kinds
+
+        implicit none
+
+        TYPE T_FORCES
+!
+!  Nonlinear model state.
+!
+          real(r8), pointer :: sustr(:,:)
+          real(r8), pointer :: svstr(:,:)
+#if !defined ANA_SMFLUX     && !defined BULK_FLUXES || \
+     defined FORWARD_FLUXES || defined READ_STRESS
+          real(r8), pointer :: sustrG(:,:,:)
+          real(r8), pointer :: svstrG(:,:,:)
+#endif
+#ifdef ADJUST_WSTRESS
+          real(r8), pointer :: ustr(:,:,:,:)
+          real(r8), pointer :: vstr(:,:,:,:)
+#endif
+          real(r8), pointer :: bustr(:,:)
+          real(r8), pointer :: bvstr(:,:)
+
+#if defined BULK_FLUXES || defined ECOSIM || defined ATM_PRESS
+          real(r8), pointer :: Pair(:,:)
+# ifndef ANA_PAIR
+          real(r8), pointer :: PairG(:,:,:)
+# endif
+#endif
+
+#ifdef WAVES_DIR
+          real(r8), pointer :: Dwave(:,:)
+# ifndef ANA_WWAVE
+          real(r8), pointer :: DwaveG(:,:,:)
+# endif
+#endif
+
+#ifdef WAVES_HEIGHT
+          real(r8), pointer :: Hwave(:,:)
+# ifndef ANA_WWAVE
+          real(r8), pointer :: HwaveG(:,:,:)
+# endif
+#endif
+
+#ifdef WAVES_LENGTH
+          real(r8), pointer :: Lwave(:,:)
+# ifndef ANA_WWAVE
+          real(r8), pointer :: LwaveG(:,:,:)
+# endif
+#endif
+
+#ifdef WAVES_TOP_PERIOD
+          real(r8), pointer :: Pwave_top(:,:)
+# ifndef ANA_WWAVE
+          real(r8), pointer :: Pwave_topG(:,:,:)
+# endif
+#endif
+
+#ifdef WAVES_BOT_PERIOD
+          real(r8), pointer :: Pwave_bot(:,:)
+# ifndef ANA_WWAVE
+          real(r8), pointer :: Pwave_botG(:,:,:)
+# endif
+#endif
+
+#if defined BBL_MODEL || defined WAV_COUPLING
+          real(r8), pointer :: Ub_swan(:,:)
+# ifndef ANA_WWAVE
+          real(r8), pointer :: Ub_swanG(:,:,:)
+# endif
+#endif
+
+#if defined TKE_WAVEDISS || defined WAV_COUPLING
+          real(r8), pointer :: wave_dissip(:,:)
+# ifndef ANA_WWAVE
+          real(r8), pointer :: wave_dissipG(:,:,:)
+# endif
+#endif
+
+#if defined SVENDSEN_ROLLER
+          real(r8), pointer :: wave_break(:,:)
+# ifndef ANA_WWAVE
+          real(r8), pointer :: wave_breakG(:,:,:)
+# endif
+#endif
+
+#ifdef SOLVE3D
+
+# ifdef SHORTWAVE
+          real(r8), pointer :: srflx(:,:)
+#  ifndef ANA_SRFLUX
+          real(r8), pointer :: srflxG(:,:,:)
+#  endif
+# endif
+
+# if defined RED_TIDE && defined DAILY_SHORTWAVE
+          real(r8), pointer :: srflx_avg(:,:)
+          real(r8), pointer :: srflxG_avg(:,:,:)
+# endif
+
+# ifdef CLOUDS
+          real(r8), pointer :: cloud(:,:)
+#  ifndef ANA_CLOUD
+          real(r8), pointer :: cloudG(:,:,:)
+#  endif
+# endif
+# ifdef BULK_FLUXES
+          real(r8), pointer :: lhflx(:,:)
+          real(r8), pointer :: lrflx(:,:)
+#  ifndef LONGWAVE
+          real(r8), pointer :: lrflxG(:,:,:)
+#  endif
+          real(r8), pointer :: shflx(:,:)
+# endif
+
+# if defined BULK_FLUXES || defined ECOSIM || \
+    (defined SHORTWAVE && defined ANA_SRFLUX)
+          real(r8), pointer :: Hair(:,:)
+#  ifndef ANA_HUMIDITY
+          real(r8), pointer :: HairG(:,:,:)
+#  endif
+          real(r8), pointer :: Tair(:,:)
+#  ifndef ANA_TAIR
+          real(r8), pointer :: TairG(:,:,:)
+#  endif
+# endif
+
+# if defined BULK_FLUXES || defined ECOSIM
+          real(r8), pointer :: Uwind(:,:)
+          real(r8), pointer :: Vwind(:,:)
+#  ifndef ANA_WINDS
+          real(r8), pointer :: UwindG(:,:,:)
+          real(r8), pointer :: VwindG(:,:,:)
+#  endif
+# endif
+
+# ifdef BULK_FLUXES
+          real(r8), pointer :: rain(:,:)
+#  ifndef ANA_RAIN
+          real(r8), pointer :: rainG(:,:,:)
+#  endif
+#  ifdef EMINUSP
+          real(r8), pointer :: evap(:,:)
+#  endif
+# endif
+
+          real(r8), pointer :: stflux(:,:,:)
+# if !defined ANA_STFLUX || !defined ANA_SSFLUX || \
+     !defined ANA_SPFLUX
+          real(r8), pointer :: stfluxG(:,:,:,:)
+# endif
+          real(r8), pointer :: stflx(:,:,:)
+# ifdef ADJUST_STFLUX
+          real(r8), pointer :: tflux(:,:,:,:,:)
+# endif
+
+          real(r8), pointer :: btflux(:,:,:)
+# if !defined ANA_BTFLUX || !defined ANA_BSFLUX || \
+     !defined ANA_BPFLUX
+          real(r8), pointer :: btfluxG(:,:,:,:)
+# endif
+          real(r8), pointer :: btflx(:,:,:)
+
+# ifdef QCORRECTION
+          real(r8), pointer :: dqdt(:,:)
+          real(r8), pointer :: sst(:,:)
+#  ifndef ANA_SST
+          real(r8), pointer :: dqdtG(:,:,:)
+          real(r8), pointer :: sstG(:,:,:)
+#  endif
+# endif
+
+# if defined SALINITY && (defined SCORRECTION || defined SRELAXATION)
+          real(r8), pointer :: sss(:,:)
+#  ifndef ANA_SSS
+          real(r8), pointer :: sssG(:,:,:)
+#  endif
+# endif
+
+# ifdef ECOSIM
+          real(r8), pointer :: SpecIr(:,:,:)
+          real(r8), pointer :: avcos(:,:,:)
+# endif
+#endif
+
+#if defined TANGENT || defined TL_IOMS
+!
+!  Tangent linear model state.
+!
+          real(r8), pointer :: tl_sustr(:,:)
+          real(r8), pointer :: tl_svstr(:,:)
+# ifdef ADJUST_WSTRESS
+          real(r8), pointer :: tl_ustr(:,:,:,:)
+          real(r8), pointer :: tl_vstr(:,:,:,:)
+# endif
+          real(r8), pointer :: tl_bustr(:,:)
+          real(r8), pointer :: tl_bvstr(:,:)
+# ifdef SOLVE3D
+          real(r8), pointer :: tl_stflux(:,:,:)
+          real(r8), pointer :: tl_stflx (:,:,:)
+          real(r8), pointer :: tl_btflux(:,:,:)
+          real(r8), pointer :: tl_btflx (:,:,:)
+#  ifdef ADJUST_STFLUX
+          real(r8), pointer :: tl_tflux(:,:,:,:,:)
+#  endif
+#  ifdef SHORTWAVE
+          real(r8), pointer :: tl_srflx(:,:)
+#  endif
+#  ifdef BULK_FLUXES
+          real(r8), pointer :: tl_lhflx(:,:)
+          real(r8), pointer :: tl_lrflx(:,:)
+          real(r8), pointer :: tl_shflx(:,:)
+#   ifdef EMINUSP
+          real(r8), pointer :: tl_evap(:,:)
+#   endif
+#  endif
+# endif
+#endif
+
+#ifdef ADJOINT
+!
+!  Adjoint model state.
+!
+          real(r8), pointer :: ad_sustr(:,:)
+          real(r8), pointer :: ad_svstr(:,:)
+# ifdef ADJUST_WSTRESS
+          real(r8), pointer :: ad_ustr(:,:,:,:)
+          real(r8), pointer :: ad_vstr(:,:,:,:)
+# endif
+          real(r8), pointer :: ad_bustr(:,:)
+          real(r8), pointer :: ad_bvstr(:,:)
+          real(r8), pointer :: ad_bustr_sol(:,:)
+          real(r8), pointer :: ad_bvstr_sol(:,:)
+# ifdef SOLVE3D
+          real(r8), pointer :: ad_stflx(:,:,:)
+          real(r8), pointer :: ad_btflx(:,:,:)
+#  ifdef ADJUST_STFLUX
+          real(r8), pointer :: ad_tflux(:,:,:,:,:)
+#  endif
+#  ifdef SHORTWAVE
+          real(r8), pointer :: ad_srflx(:,:)
+#  endif
+#  ifdef BULK_FLUXES
+          real(r8), pointer :: ad_lhflx(:,:)
+          real(r8), pointer :: ad_lrflx(:,:)
+          real(r8), pointer :: ad_shflx(:,:)
+#   ifdef EMINUSP
+          real(r8), pointer :: ad_evap(:,:)
+#   endif
+#  endif
+# endif
+#endif
+
+#if defined ADJUST_WSTRESS || defined ADJUST_STFLUX
+!
+!  Working arrays to store adjoint impulse forcing, background error
+!  covariance, background-error standard deviations, or descent
+!  conjugate vectors (directions).
+!
+# if defined FOUR_DVAR || defined IMPULSE
+#  ifdef ADJUST_WSTRESS
+          real(r8), pointer :: b_sustr(:,:)
+          real(r8), pointer :: b_svstr(:,:)
+#  endif
+#  if defined ADJUST_STFLUX && defined SOLVE3D
+          real(r8), pointer :: b_stflx(:,:,:)
+#  endif
+#  ifdef FOUR_DVAR
+#   ifdef ADJUST_WSTRESS
+          real(r8), pointer :: d_sustr(:,:,:)
+          real(r8), pointer :: d_svstr(:,:,:)
+          real(r8), pointer :: e_sustr(:,:)
+          real(r8), pointer :: e_svstr(:,:)
+#   endif
+#   if defined ADJUST_STFLUX && defined SOLVE3D
+          real(r8), pointer :: d_stflx(:,:,:,:)
+          real(r8), pointer :: e_stflx(:,:,:)
+#   endif
+#  endif
+# endif
+#endif
+
+        END TYPE T_FORCES
+
+        TYPE (T_FORCES), allocatable :: FORCES(:)
+
+      CONTAINS
+
+      SUBROUTINE allocate_forces (ng, LBi, UBi, LBj, UBj)
+!
+!=======================================================================
+!                                                                      !
+!  This routine allocates all variables in the module for all nested   !
+!  grids.                                                              !
+!                                                                      !
+!=======================================================================
+!
+      USE mod_param
+#ifdef BIOLOGY
+      USE mod_biology
+#endif
+#if defined ADJUST_STFLUX || defined ADJUST_WSTRESS
+      USE mod_scalars
+#endif
+!
+!  Local variable declarations.
+!
+      integer, intent(in) :: ng, LBi, UBi, LBj, UBj
+!
+!  Local variable declarations.
+!
+      real(r8) :: size2d
+!
+!-----------------------------------------------------------------------
+!  Allocate module variables.
+!-----------------------------------------------------------------------
+!
+      IF (ng.eq.1) allocate ( FORCES(Ngrids) )
+!
+!  Set horizontal array size.
+!
+      size2d=REAL((UBi-LBi+1)*(UBj-LBj+1),r8)
+!
+!  Nonlinear model state
+!
+      allocate ( FORCES(ng) % sustr(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+      allocate ( FORCES(ng) % svstr(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+#if !defined ANA_SMFLUX     && !defined BULK_FLUXES || \
+     defined FORWARD_FLUXES || defined READ_STRESS
+      allocate ( FORCES(ng) % sustrG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+
+      allocate ( FORCES(ng) % svstrG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+#endif
+#ifdef ADJUST_WSTRESS
+      allocate ( FORCES(ng) % ustr(LBi:UBi,LBj:UBj,Nfrec(ng),2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*REAL(Nfrec(ng),r8)*size2d
+
+      allocate ( FORCES(ng) % vstr(LBi:UBi,LBj:UBj,Nfrec(ng),2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*REAL(Nfrec(ng),r8)*size2d
+#endif
+      allocate ( FORCES(ng) % bustr(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+      allocate ( FORCES(ng) % bvstr(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+#if defined BULK_FLUXES || defined ECOSIM || defined ATM_PRESS
+      allocate ( FORCES(ng) % Pair(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+# ifndef ANA_PAIR
+      allocate ( FORCES(ng) % PairG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+# endif
+#endif
+
+#ifdef WAVES_DIR
+      allocate ( FORCES(ng) % Dwave(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+# ifndef ANA_WWAVE
+      allocate ( FORCES(ng) % DwaveG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+# endif
+#endif
+
+#ifdef WAVES_HEIGHT
+      allocate ( FORCES(ng) % Hwave(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+# ifndef ANA_WWAVE
+      allocate ( FORCES(ng) % HwaveG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+# endif
+#endif
+
+#ifdef WAVES_LENGTH
+      allocate ( FORCES(ng) % Lwave(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+# ifndef ANA_WWAVE
+      allocate ( FORCES(ng) % LwaveG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+# endif
+#endif
+
+#ifdef WAVES_TOP_PERIOD
+      allocate ( FORCES(ng) % Pwave_top(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+# ifndef ANA_WWAVE
+      allocate ( FORCES(ng) % Pwave_topG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+# endif
+#endif
+
+#ifdef WAVES_BOT_PERIOD
+      allocate ( FORCES(ng) % Pwave_bot(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+# ifndef ANA_WWAVE
+      allocate ( FORCES(ng) % Pwave_botG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+# endif
+#endif
+
+#if defined BBL_MODEL || defined WAV_COUPLING
+      allocate ( FORCES(ng) % Ub_swan(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+# ifndef ANA_WWAVE
+      allocate ( FORCES(ng) % Ub_swanG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+# endif
+#endif
+
+#if defined TKE_WAVEDISS || defined WAV_COUPLING
+      allocate ( FORCES(ng) % wave_dissip(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+# ifndef ANA_WWAVE
+      allocate ( FORCES(ng) % Wave_dissipG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+# endif
+#endif
+
+#if defined SVENDSEN_ROLLER
+      allocate ( FORCES(ng) % wave_break(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+# ifndef ANA_WWAVE
+      allocate ( FORCES(ng) % Wave_breakG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+# endif
+#endif
+
+#ifdef SOLVE3D
+
+# ifdef SHORTWAVE
+      allocate ( FORCES(ng) % srflx(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+#  ifndef ANA_SRFLUX
+      allocate ( FORCES(ng) % srflxG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+size2d
+#  endif
+# endif
+
+# if defined RED_TIDE && defined DAILY_SHORTWAVE
+      allocate ( FORCES(ng) % srflx_avg(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+      allocate ( FORCES(ng) % srflxG_avg(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+# endif
+
+# ifdef CLOUDS
+      allocate ( FORCES(ng) % cloud(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+#  ifndef ANA_CLOUD
+      allocate ( FORCES(ng) % cloudG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+#  endif
+# endif
+
+# ifdef BULK_FLUXES
+      allocate ( FORCES(ng) % lhflx(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+      allocate ( FORCES(ng) % lrflx(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+#  ifndef LONGWAVE
+      allocate ( FORCES(ng) % lrflxG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+#  endif
+
+      allocate ( FORCES(ng) % shflx(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+# endif
+
+# if defined BULK_FLUXES || defined ECOSIM || \
+    (defined SHORTWAVE && defined ANA_SRFLUX)
+      allocate ( FORCES(ng) % Hair(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+#  ifndef ANA_HUMIDITY
+      allocate ( FORCES(ng) % HairG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+#  endif
+
+      allocate ( FORCES(ng) % Tair(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+#  ifndef ANA_TAIR
+      allocate ( FORCES(ng) % TairG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+#  endif
+# endif
+
+# if defined BULK_FLUXES || defined ECOSIM
+      allocate ( FORCES(ng) % Uwind(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+      allocate ( FORCES(ng) % Vwind(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+#  ifndef ANA_WINDS
+      allocate ( FORCES(ng) % UwindG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+
+      allocate ( FORCES(ng) % VwindG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+#  endif
+# endif
+
+# ifdef BULK_FLUXES
+      allocate ( FORCES(ng) % rain(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+#  ifndef ANA_RAIN
+      allocate ( FORCES(ng) % rainG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+
+#  endif
+#  ifdef EMINUSP
+      allocate ( FORCES(ng) % evap(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+#  endif
+# endif
+
+      allocate ( FORCES(ng) % stflux(LBi:UBi,LBj:UBj,NT(ng)) )
+      Dmem(ng)=Dmem(ng)+REAL(NT(ng),r8)*size2d
+
+# if !defined ANA_STFLUX || !defined ANA_SSFLUX || \
+     !defined ANA_SPFLUX
+      allocate ( FORCES(ng) % stfluxG(LBi:UBi,LBj:UBj,2,NT(ng)) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*REAL(NT(ng),r8)*size2d
+
+# endif
+
+      allocate ( FORCES(ng) % stflx(LBi:UBi,LBj:UBj,NT(ng)) )
+      Dmem(ng)=Dmem(ng)+REAL(NT(ng),r8)*size2d
+
+# ifdef ADJUST_STFLUX
+      allocate ( FORCES(ng) % tflux(LBi:UBi,LBj:UBj,nfrec(ng),          &
+     &                              2,NT(ng)) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*REAL(nfrec(ng)*NT(ng),r8)*size2d
+
+# endif
+
+      allocate ( FORCES(ng) % btflux(LBi:UBi,LBj:UBj,NT(ng)) )
+      Dmem(ng)=Dmem(ng)+REAL(NT(ng),r8)*size2d
+
+# if !defined ANA_BTFLUX || !defined ANA_BSFLUX || \
+     !defined ANA_BPFLUX
+      allocate ( FORCES(ng) % btfluxG(LBi:UBi,LBj:UBj,2,NT(ng)) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*REAL(NT(ng),r8)*size2d
+# endif
+
+      allocate ( FORCES(ng) % btflx(LBi:UBi,LBj:UBj,NT(ng)) )
+      Dmem(ng)=Dmem(ng)+REAL(NT(ng),r8)*size2d
+
+# ifdef QCORRECTION
+      allocate ( FORCES(ng) % dqdt(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+      allocate ( FORCES(ng) % sst(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+#  ifndef ANA_SST
+      allocate ( FORCES(ng) % dqdtG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+
+      allocate ( FORCES(ng) % sstG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+#  endif
+# endif
+
+# if defined SALINITY && (defined SCORRECTION || defined SRELAXATION)
+      allocate ( FORCES(ng) % sss(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+#  ifndef ANA_SSS
+      allocate ( FORCES(ng) % sssG(LBi:UBi,LBj:UBj,2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*size2d
+#  endif
+# endif
+
+# ifdef ECOSIM
+      allocate ( FORCES(ng) % SpecIr(LBi:UBi,LBj:UBj,NBands) )
+      Dmem(ng)=Dmem(ng)+REAL(NBands,r8)*size2d
+
+      allocate ( FORCES(ng) % avcos(LBi:UBi,LBj:UBj,NBands) )
+      Dmem(ng)=Dmem(ng)+REAL(NBands,r8)*size2d
+# endif
+
+#endif
+
+#if defined TANGENT || defined TL_IOMS
+!
+!  Tangent linear model state
+!
+      allocate ( FORCES(ng) % tl_sustr(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+      allocate ( FORCES(ng) % tl_svstr(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+# ifdef ADJUST_WSTRESS
+      allocate ( FORCES(ng) % tl_ustr(LBi:UBi,LBj:UBj,Nfrec(ng),2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*REAL(Nfrec(ng),r8)*size2d
+
+      allocate ( FORCES(ng) % tl_vstr(LBi:UBi,LBj:UBj,Nfrec(ng),2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*REAL(Nfrec(ng),r8)*size2d
+# endif
+      allocate ( FORCES(ng) % tl_bustr(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+      allocate ( FORCES(ng) % tl_bvstr(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+# ifdef SOLVE3D
+      allocate ( FORCES(ng) % tl_stflux(LBi:UBi,LBj:UBj,NT(ng)) )
+      Dmem(ng)=Dmem(ng)+REAL(NT(ng),r8)*size2d
+
+      allocate ( FORCES(ng) % tl_stflx(LBi:UBi,LBj:UBj,NT(ng)) )
+      Dmem(ng)=Dmem(ng)+REAL(NT(ng),r8)*size2d
+
+      allocate ( FORCES(ng) % tl_btflux(LBi:UBi,LBj:UBj,NT(ng)) )
+      Dmem(ng)=Dmem(ng)+REAL(NT(ng),r8)*size2d
+
+      allocate ( FORCES(ng) % tl_btflx(LBi:UBi,LBj:UBj,NT(ng)) )
+      Dmem(ng)=Dmem(ng)+REAL(NT(ng),r8)*size2d
+#  ifdef ADJUST_STFLUX
+      allocate ( FORCES(ng) % tl_tflux(LBi:UBi,LBj:UBj,Nfrec(ng),       &
+     &                                 2,NT(ng)) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*REAL(Nfrec(ng)*NT(ng),r8)*size2d
+#  endif
+#  ifdef SHORTWAVE
+      allocate ( FORCES(ng) % tl_srflx(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+#  endif
+#  ifdef BULK_FLUXES
+      allocate ( FORCES(ng) % tl_lhflx(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+      allocate ( FORCES(ng) % tl_lrflx(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+      allocate ( FORCES(ng) % tl_shflx(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+#   ifdef EMINUSP
+      allocate ( FORCES(ng) % tl_evap(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+#   endif
+#  endif
+# endif
+#endif
+
+#ifdef ADJOINT
+!
+!  Adjoint model state
+!
+      allocate ( FORCES(ng) % ad_sustr(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+      allocate ( FORCES(ng) % ad_svstr(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+# ifdef ADJUST_WSTRESS
+      allocate ( FORCES(ng) % ad_ustr(LBi:UBi,LBj:UBj,Nfrec(ng),2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*REAL(Nfrec(ng),r8)*size2d
+
+      allocate ( FORCES(ng) % ad_vstr(LBi:UBi,LBj:UBj,Nfrec(ng),2) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*REAL(Nfrec(ng),r8)*size2d
+# endif
+      allocate ( FORCES(ng) % ad_bustr(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+      allocate ( FORCES(ng) % ad_bvstr(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+      allocate ( FORCES(ng) % ad_bustr_sol(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+      allocate ( FORCES(ng) % ad_bvstr_sol(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+# ifdef SOLVE3D
+      allocate ( FORCES(ng) % ad_stflx(LBi:UBi,LBj:UBj,NT(ng)) )
+      Dmem(ng)=Dmem(ng)+REAL(NT(ng),r8)*size2d
+
+      allocate ( FORCES(ng) % ad_btflx(LBi:UBi,LBj:UBj,NT(ng)) )
+      Dmem(ng)=Dmem(ng)+REAL(NT(ng),r8)*size2d
+#  ifdef ADJUST_STFLUX
+      allocate ( FORCES(ng) % ad_tflux(LBi:UBi,LBj:UBj,Nfrec(ng),       &
+     &                                 2,NT(ng)) )
+      Dmem(ng)=Dmem(ng)+2.0_r8*REAL(Nfrec(ng)*NT(ng),r8)*size2d
+#  endif
+#  ifdef SHORTWAVE
+      allocate ( FORCES(ng) % ad_srflx(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+#  endif
+#  ifdef BULK_FLUXES
+      allocate ( FORCES(ng) % ad_lhflx(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+      allocate ( FORCES(ng) % ad_lrflx(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+      allocate ( FORCES(ng) % ad_shflx(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+#   ifdef EMINUSP
+      allocate ( FORCES(ng) % ad_evap(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+#   endif
+#  endif
+# endif
+#endif
+
+#if defined ADJUST_WSTRESS || defined ADJUST_STFLUX
+!
+!  Working arrays to store adjoint impulse forcing, background error
+!  covariance, background-error standard deviations, or descent
+!  conjugate vectors (directions).
+!
+# if defined FOUR_DVAR || defined IMPULSE
+#  ifdef ADJUST_WSTRESS
+      allocate ( FORCES(ng) % b_sustr(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+      allocate ( FORCES(ng) % b_svstr(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+#  endif
+#  if defined ADJUST_STFLUX && defined SOLVE3D
+      allocate ( FORCES(ng) % b_stflx(LBi:UBi,LBj:UBj,NT(ng)) )
+      Dmem(ng)=Dmem(ng)+REAL(NT(ng),r8)*size2d
+#  endif
+# endif
+# ifdef FOUR_DVAR
+#  ifdef ADJUST_WSTRESS
+      allocate ( FORCES(ng) % d_sustr(LBi:UBi,LBj:UBj,Nfrec(ng)) )
+      Dmem(ng)=Dmem(ng)+REAL(Nfrec(ng),r8)*size2d
+
+      allocate ( FORCES(ng) % d_svstr(LBi:UBi,LBj:UBj,Nfrec(ng)) )
+      Dmem(ng)=Dmem(ng)+REAL(Nfrec(ng),r8)*size2d
+
+      allocate ( FORCES(ng) % e_sustr(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+
+      allocate ( FORCES(ng) % e_svstr(LBi:UBi,LBj:UBj) )
+      Dmem(ng)=Dmem(ng)+size2d
+#  endif
+#  if defined ADJUST_STFLUX && defined SOLVE3D
+      allocate ( FORCES(ng) % d_stflx(LBi:UBi,LBj:UBj,                  &
+     &                                Nfrec(ng),NT(ng)) )
+      Dmem(ng)=Dmem(ng)+REAL(Nfrec(ng)*NT(ng),r8)*size2d
+
+      allocate ( FORCES(ng) % e_stflx(LBi:UBi,LBj:UBj,NT(ng)) )
+      Dmem(ng)=Dmem(ng)+REAL(NT(ng),r8)*size2d
+#  endif
+# endif
+#endif
+
+      RETURN
+      END SUBROUTINE allocate_forces
+
+      SUBROUTINE initialize_forces (ng, tile, model)
+!
+!=======================================================================
+!                                                                      !
+!  This routine initialize all variables in the module using first     !
+!  touch distribution policy. In shared-memory configuration, this     !
+!  operation actually performs propagation of the  "shared arrays"     !
+!  across the cluster, unless another policy is specified to           !
+!  override the default.                                               !
+!                                                                      !
+!=======================================================================
+!
+      USE mod_param
+#ifdef BIOLOGY
+      USE mod_biology
+#endif
+#if defined ADJUST_STFLUX || defined ADJUST_WSTRESS
+      USE mod_scalars
+#endif
+!
+!  Imported variable declarations.
+!
+      integer, intent(in) :: ng, tile, model
+!
+!  Local variable declarations.
+!
+      integer :: Imin, Imax, Jmin, Jmax
+      integer :: i, j, k
+#ifdef SOLVE3D
+      integer :: itrc
+#endif
+
+      real(r8), parameter :: IniVal = 0.0_r8
+
+#include "set_bounds.h"
+!
+!  Set array initialization range.
+!
+#ifdef DISTRIBUTE
+      Imin=BOUNDS(ng)%LBi(tile)
+      Imax=BOUNDS(ng)%UBi(tile)
+      Jmin=BOUNDS(ng)%LBj(tile)
+      Jmax=BOUNDS(ng)%UBj(tile)
+#else
+      IF (DOMAIN(ng)%Western_Edge(tile)) THEN
+        Imin=BOUNDS(ng)%LBi(tile)
+      ELSE
+        Imin=Istr
+      END IF
+      IF (DOMAIN(ng)%Eastern_Edge(tile)) THEN
+        Imax=BOUNDS(ng)%UBi(tile)
+      ELSE
+        Imax=Iend
+      END IF
+      IF (DOMAIN(ng)%Southern_Edge(tile)) THEN
+        Jmin=BOUNDS(ng)%LBj(tile)
+      ELSE
+        Jmin=Jstr
+      END IF
+      IF (DOMAIN(ng)%Northern_Edge(tile)) THEN
+        Jmax=BOUNDS(ng)%UBj(tile)
+      ELSE
+        Jmax=Jend
+      END IF
+#endif
+!
+!-----------------------------------------------------------------------
+!  Initialize module variables.
+!-----------------------------------------------------------------------
+!
+!  Nonlinear model state.
+!
+      IF ((model.eq.0).or.(model.eq.iNLM)) THEN
+        DO j=Jmin,Jmax
+          DO i=Imin,Imax
+#ifdef ADJUST_WSTRESS
+            DO k=1,Nfrec(ng)
+              FORCES(ng) % ustr(i,j,k,1) = IniVal
+              FORCES(ng) % ustr(i,j,k,2) = IniVal
+              FORCES(ng) % vstr(i,j,k,1) = IniVal
+              FORCES(ng) % vstr(i,j,k,2) = IniVal
+            END DO
+#endif
+            FORCES(ng) % sustr(i,j) = IniVal
+            FORCES(ng) % svstr(i,j) = IniVal
+#if !defined ANA_SMFLUX     && !defined BULK_FLUXES || \
+     defined FORWARD_FLUXES
+            FORCES(ng) % sustrG(i,j,1) = IniVal
+            FORCES(ng) % sustrG(i,j,2) = IniVal
+            FORCES(ng) % svstrG(i,j,1) = IniVal
+            FORCES(ng) % svstrG(i,j,2) = IniVal
+#endif
+            FORCES(ng) % bustr(i,j) = IniVal
+            FORCES(ng) % bvstr(i,j) = IniVal
+#if defined BULK_FLUXES || defined ECOSIM || defined ATM_PRESS
+            FORCES(ng) % Pair(i,j) = IniVal
+# ifndef ANA_PAIR
+            FORCES(ng) % PairG(i,j,1) = IniVal
+            FORCES(ng) % PairG(i,j,2) = IniVal
+# endif
+#endif
+#ifdef WAVES_DIR
+            FORCES(ng) % Dwave(i,j) = IniVal
+# ifndef ANA_WWAVE
+            FORCES(ng) % DwaveG(i,j,1) = IniVal
+            FORCES(ng) % DwaveG(i,j,2) = IniVal
+# endif
+#endif
+#ifdef WAVES_HEIGHT
+            FORCES(ng) % Hwave(i,j) = IniVal
+# ifndef ANA_WWAVE
+            FORCES(ng) % HwaveG(i,j,1) = IniVal
+            FORCES(ng) % HwaveG(i,j,2) = IniVal
+# endif
+#endif
+#ifdef WAVES_LENGTH
+            FORCES(ng) % Lwave(i,j) = IniVal
+# ifndef ANA_WWAVE
+            FORCES(ng) % LwaveG(i,j,1) = IniVal
+            FORCES(ng) % LwaveG(i,j,2) = IniVal
+# endif
+#endif
+#ifdef WAVES_TOP_PERIOD
+            FORCES(ng) % Pwave_top(i,j) = IniVal
+# ifndef ANA_WWAVE
+            FORCES(ng) % Pwave_topG(i,j,1) = IniVal
+            FORCES(ng) % Pwave_topG(i,j,2) = IniVal
+# endif
+#endif
+#ifdef WAVES_BOT_PERIOD
+            FORCES(ng) % Pwave_bot(i,j) = IniVal
+# ifndef ANA_WWAVE
+            FORCES(ng) % Pwave_botG(i,j,1) = IniVal
+            FORCES(ng) % Pwave_botG(i,j,2) = IniVal
+# endif
+#endif
+#if defined BBL_MODEL || defined WAV_COUPLING
+            FORCES(ng) % Ub_swan(i,j) = IniVal
+# ifndef ANA_WWAVE
+            FORCES(ng) % Ub_swanG(i,j,1) = IniVal
+            FORCES(ng) % Ub_swanG(i,j,2) = IniVal
+# endif
+#endif
+#if defined TKE_WAVEDISS || defined WAV_COUPLING
+            FORCES(ng) % Wave_dissip(i,j) = IniVal
+# ifndef ANA_WWAVE
+            FORCES(ng) % Wave_dissipG(i,j,1) = IniVal
+            FORCES(ng) % Wave_dissipG(i,j,2) = IniVal
+# endif
+#endif
+#if defined SVENDSEN_ROLLER
+            FORCES(ng) % Wave_break(i,j) = IniVal
+# ifndef ANA_WWAVE
+            FORCES(ng) % Wave_breakG(i,j,1) = IniVal
+            FORCES(ng) % Wave_breakG(i,j,2) = IniVal
+# endif
+#endif
+
+#ifdef SOLVE3D
+# ifdef SHORTWAVE
+            FORCES(ng) % srflx(i,j) = IniVal
+#  ifndef ANA_SRFLUX
+            FORCES(ng) % srflxG(i,j,1) = IniVal
+            FORCES(ng) % srflxG(i,j,2) = IniVal
+#  endif
+# endif
+# if defined RED_TIDE && defined DAILY_SHORTWAVE
+            FORCES(ng) % srflx_avg(i,j) = IniVal
+            FORCES(ng) % srflxG_avg(i,j,1) = IniVal
+            FORCES(ng) % srflxG_avg(i,j,2) = IniVal
+# endif
+# ifdef CLOUDS
+            FORCES(ng) % cloud(i,j) = IniVal
+#  ifndef ANA_CLOUD
+            FORCES(ng) % cloudG(i,j,1) = IniVal
+            FORCES(ng) % cloudG(i,j,2) = IniVal
+#  endif
+# endif
+# ifdef BULK_FLUXES
+            FORCES(ng) % lhflx(i,j) = IniVal
+            FORCES(ng) % lrflx(i,j) = IniVal
+            FORCES(ng) % shflx(i,j) = IniVal
+# endif
+# if defined BULK_FLUXES || defined ECOSIM || \
+    (defined SHORTWAVE && defined ANA_SRFLUX)
+            FORCES(ng) % Hair(i,j) = IniVal
+            FORCES(ng) % Tair(i,j) = IniVal
+# endif
+# if defined BULK_FLUXES || defined ECOSIM
+            FORCES(ng) % Uwind(i,j) = IniVal
+            FORCES(ng) % Vwind(i,j) = IniVal
+# endif
+# ifdef BULK_FLUXES
+            FORCES(ng) % rain(i,j) = IniVal
+#  ifdef EMINUSP
+            FORCES(ng) % evap(i,j) = IniVal
+#  endif
+# endif
+# if !defined LONGWAVE && defined BULK_FLUXES
+            FORCES(ng) % lrflxG(i,j,1) = IniVal
+            FORCES(ng) % lrflxG(i,j,2) = IniVal
+# endif
+# if defined BULK_FLUXES || defined ECOSIM
+#  ifndef ANA_HUMIDITY
+            FORCES(ng) % HairG(i,j,1) = IniVal
+            FORCES(ng) % HairG(i,j,2) = IniVal
+#  endif
+# endif
+# if defined BULK_FLUXES || defined ECOSIM
+#  ifndef ANA_TAIR
+            FORCES(ng) % TairG(i,j,1) = IniVal
+            FORCES(ng) % TairG(i,j,2) = IniVal
+#  endif
+#  ifndef ANA_WINDS
+            FORCES(ng) % UwindG(i,j,1) = IniVal
+            FORCES(ng) % UwindG(i,j,2) = IniVal
+            FORCES(ng) % VwindG(i,j,1) = IniVal
+            FORCES(ng) % VwindG(i,j,2) = IniVal
+#  endif
+# endif
+# if !defined ANA_RAIN && defined BULK_FLUXES
+            FORCES(ng) % rainG(i,j,1) = IniVal
+            FORCES(ng) % rainG(i,j,2) = IniVal
+# endif
+# ifdef QCORRECTION
+            FORCES(ng) % dqdt(i,j) = IniVal
+            FORCES(ng) % sst(i,j) = IniVal
+#  ifndef ANA_SST
+            FORCES(ng) % dqdtG(i,j,1) = IniVal
+            FORCES(ng) % dqdtG(i,j,2) = IniVal
+            FORCES(ng) % sstG(i,j,1) = IniVal
+            FORCES(ng) % sstG(i,j,2) = IniVal
+#  endif
+# endif
+# if defined SALINITY && (defined SCORRECTION || defined SRELAXATION)
+            FORCES(ng) % sss(i,j) = IniVal
+#  ifndef ANA_SSS
+            FORCES(ng) % sssG(i,j,1) = IniVal
+            FORCES(ng) % sssG(i,j,2) = IniVal
+#  endif
+# endif
+            DO itrc=1,NT(ng)
+              FORCES(ng) % stflux(i,j,itrc) = IniVal
+# if !defined ANA_STFLUX || !defined ANA_SSFLUX || \
+     !defined ANA_SPFLUX
+              FORCES(ng) % stfluxG(i,j,1,itrc) = IniVal
+              FORCES(ng) % stfluxG(i,j,2,itrc) = IniVal
+# endif
+              FORCES(ng) % stflx(i,j,itrc) = IniVal
+# ifdef ADJUST_STFLUX
+              DO k=1,Nfrec(ng)
+                FORCES(ng) % tflux(i,j,k,1,itrc) = IniVal
+                FORCES(ng) % tflux(i,j,k,2,itrc) = IniVal
+              END DO
+# endif
+
+              FORCES(ng) % btflux(i,j,itrc) = IniVal
+# if !defined ANA_BTFLUX || !defined ANA_BSFLUX || \
+     !defined ANA_BPFLUX
+              FORCES(ng) % btfluxG(i,j,1,itrc) = IniVal
+              FORCES(ng) % btfluxG(i,j,2,itrc) = IniVal
+# endif
+              FORCES(ng) % btflx(i,j,itrc) = IniVal
+            END DO
+# ifdef ECOSIM
+            DO itrc=1,NBands
+              FORCES(ng) % SpecIr(i,j,itrc) = IniVal
+              FORCES(ng) % avcos(i,j,itrc) = IniVal
+            END DO
+# endif
+#endif
+          END DO
+        END DO
+      END IF
+
+#if defined TANGENT || defined TL_IOMS
+!
+!  Tangent linear model state.
+!
+      IF ((model.eq.0).or.(model.eq.iTLM).or.(model.eq.iRPM)) THEN
+        DO j=Jmin,Jmax
+          DO i=Imin,Imax
+# ifdef ADJUST_WSTRESS
+            DO k=1,Nfrec(ng)
+              FORCES(ng) % tl_ustr(i,j,k,1) = IniVal
+              FORCES(ng) % tl_ustr(i,j,k,2) = IniVal
+              FORCES(ng) % tl_vstr(i,j,k,1) = IniVal
+              FORCES(ng) % tl_vstr(i,j,k,2) = IniVal
+            END DO
+# endif
+            FORCES(ng) % tl_sustr(i,j) = IniVal
+            FORCES(ng) % tl_svstr(i,j) = IniVal
+            FORCES(ng) % tl_bustr(i,j) = IniVal
+            FORCES(ng) % tl_bvstr(i,j) = IniVal
+          END DO
+# ifdef SOLVE3D
+#  ifdef SHORTWAVE
+          DO i=Imin,Imax
+            FORCES(ng) % tl_srflx(i,j) = IniVal
+          END DO
+#  endif
+#  ifdef BULK_FLUXES
+          DO i=Imin,Imax
+            FORCES(ng) % tl_lhflx(i,j) = IniVal
+            FORCES(ng) % tl_lrflx(i,j) = IniVal
+            FORCES(ng) % tl_shflx(i,j) = IniVal
+#   ifdef EMINUSP
+            FORCES(ng) % tl_evap(i,j) = IniVal
+#   endif
+          END DO
+#  endif
+          DO itrc=1,NT(ng)
+            DO i=Imin,Imax
+#  ifdef ADJUST_STFLUX
+              DO k=1,Nfrec(ng)
+                FORCES(ng) % tl_tflux(i,j,k,1,itrc) = IniVal
+                FORCES(ng) % tl_tflux(i,j,k,2,itrc) = IniVal
+              END DO
+#  endif
+              FORCES(ng) % tl_stflux(i,j,itrc) = IniVal
+              FORCES(ng) % tl_stflx (i,j,itrc) = IniVal
+              FORCES(ng) % tl_btflux(i,j,itrc) = IniVal
+              FORCES(ng) % tl_btflx (i,j,itrc) = IniVal
+            END DO
+          END DO
+# endif
+        END DO
+      END IF
+#endif
+
+#ifdef ADJOINT
+!
+!  Adjoint model state.
+!
+      IF ((model.eq.0).or.(model.eq.iADM)) THEN
+        DO j=Jmin,Jmax
+          DO i=Imin,Imax
+# ifdef ADJUST_WSTRESS
+            DO k=1,Nfrec(ng)
+              FORCES(ng) % ad_ustr(i,j,k,1) = IniVal
+              FORCES(ng) % ad_ustr(i,j,k,2) = IniVal
+              FORCES(ng) % ad_vstr(i,j,k,1) = IniVal
+              FORCES(ng) % ad_vstr(i,j,k,2) = IniVal
+            END DO
+# endif
+            FORCES(ng) % ad_sustr(i,j) = IniVal
+            FORCES(ng) % ad_svstr(i,j) = IniVal
+            FORCES(ng) % ad_bustr(i,j) = IniVal
+            FORCES(ng) % ad_bvstr(i,j) = IniVal
+            FORCES(ng) % ad_bustr_sol(i,j) = IniVal
+            FORCES(ng) % ad_bvstr_sol(i,j) = IniVal
+          END DO
+# ifdef SOLVE3D
+#  ifdef SHORTWAVE
+          DO i=Imin,Imax
+            FORCES(ng) % ad_srflx(i,j) = IniVal
+          END DO
+#  endif
+#  ifdef BULK_FLUXES
+          DO i=Imin,Imax
+            FORCES(ng) % ad_lhflx(i,j) = IniVal
+            FORCES(ng) % ad_lrflx(i,j) = IniVal
+            FORCES(ng) % ad_shflx(i,j) = IniVal
+#   ifdef EMINUSP
+            FORCES(ng) % ad_evap(i,j) = IniVal
+#   endif
+          END DO
+#  endif
+          DO itrc=1,NT(ng)
+            DO i=Imin,Imax
+#  ifdef ADJUST_STFLUX
+              DO k=1,Nfrec(ng)
+                FORCES(ng) % ad_tflux(i,j,k,1,itrc) = IniVal
+                FORCES(ng) % ad_tflux(i,j,k,2,itrc) = IniVal
+              END DO
+#  endif
+              FORCES(ng) % ad_stflx(i,j,itrc) = IniVal
+              FORCES(ng) % ad_btflx(i,j,itrc) = IniVal
+            END DO
+          END DO
+# endif
+        END DO
+      END IF
+#endif
+
+#if defined ADJUST_WSTRESS || defined ADJUST_STFLUX
+!
+!  Working arrays to store adjoint impulse forcing, background error
+!  covariance, background-error standard deviations, or descent
+!  conjugate vectors (directions).
+!
+# if defined FOUR_DVAR || defined IMPULSE
+      IF (model.eq.0) THEN
+#  ifdef ADJUST_WSTRESS
+        DO j=Jmin,Jmax
+          DO i=Imin,Imax
+            FORCES(ng) % b_sustr(i,j) = IniVal
+            FORCES(ng) % b_svstr(i,j) = IniVal
+#   ifdef FOUR_DVAR
+            FORCES(ng) % e_sustr(i,j) = IniVal
+            FORCES(ng) % e_svstr(i,j) = IniVal
+            DO k=1,Nfrec(ng)
+              FORCES(ng) % d_sustr(i,j,k) = IniVal
+              FORCES(ng) % d_svstr(i,j,k) = IniVal
+            END DO
+#   endif
+          END DO
+        END DO
+#  endif
+#  if defined ADJUST_STFLUX && defined SOLVE3D
+        DO itrc=1,NT(ng)
+          DO j=Jmin,Jmax
+            DO i=Imin,Imax
+              FORCES(ng) % b_stflx(i,j,itrc) = IniVal
+#   ifdef FOUR_DVAR
+              FORCES(ng) % e_stflx(i,j,itrc) = IniVal
+              DO k=1,Nfrec(ng)
+                FORCES(ng) % d_stflx(i,j,k,itrc) = IniVal
+              END DO
+#   endif
+            END DO
+          END DO
+        END DO
+#  endif
+      END IF
+# endif
+#endif
+
+      RETURN
+      END SUBROUTINE initialize_forces
+
+      END MODULE mod_forces

--- a/apps/common/modified_src/roms-trunk1041/set_data.F
+++ b/apps/common/modified_src/roms-trunk1041/set_data.F
@@ -1,0 +1,1453 @@
+#include "cppdefs.h"
+#ifdef NONLINEAR
+      SUBROUTINE set_data (ng, tile)
+!
+!svn $Id: set_data.F 1041 2020-10-16 00:00:17Z arango $
+!================================================== Hernan G. Arango ===
+!  Copyright (c) 2002-2020 The ROMS/TOMS Group                         !
+!    Licensed under a MIT/X style license                              !
+!    See License_ROMS.txt                                              !
+!=======================================================================
+!                                                                      !
+!  This subroutine processes forcing, boundary, climatology, and       !
+!  other input data. It time-interpolates between snapshots.           !
+!                                                                      !
+!=======================================================================
+!
+      USE mod_param
+!
+!  Imported variable declarations.
+!
+      integer, intent(in) :: ng, tile
+!
+!  Local variable declarations.
+!
+# include "tile.h"
+!
+# ifdef PROFILE
+      CALL wclock_on (ng, iNLM, 4, __LINE__, __FILE__)
+# endif
+      CALL set_data_tile (ng, tile,                                     &
+     &                    LBi, UBi, LBj, UBj,                           &
+     &                    IminS, ImaxS, JminS, JmaxS)
+# ifdef PROFILE
+      CALL wclock_off (ng, iNLM, 4, __LINE__, __FILE__)
+# endif
+!
+      RETURN
+      END SUBROUTINE set_data
+!
+!***********************************************************************
+      SUBROUTINE set_data_tile (ng, tile,                               &
+     &                          LBi, UBi, LBj, UBj,                     &
+     &                          IminS, ImaxS, JminS, JmaxS)
+!***********************************************************************
+!
+      USE mod_param
+# if defined HYPOXIA_SRM || defined RED_TIDE
+      USE mod_biology
+# endif
+      USE mod_boundary
+      USE mod_clima
+      USE mod_forces
+      USE mod_grid
+      USE mod_mixing
+      USE mod_ncparam
+      USE mod_ocean
+      USE mod_stepping
+      USE mod_scalars
+      USE mod_sources
+!
+# ifdef ANALYTICAL
+      USE analytical_mod
+# endif
+      USE exchange_2d_mod
+      USE set_2dfld_mod
+# ifdef SOLVE3D
+      USE set_3dfld_mod
+# endif
+# ifdef DISTRIBUTE
+#  if defined WET_DRY
+      USE distribute_mod,  ONLY : mp_boundary
+#  endif
+      USE mp_exchange_mod, ONLY : mp_exchange2d
+#  ifdef SOLVE3D
+      USE mp_exchange_mod, ONLY : mp_exchange3d
+#  endif
+# endif
+      USE strings_mod,     ONLY : FoundError
+!
+      implicit none
+!
+!  Imported variable declarations.
+!
+      integer, intent(in) :: ng, tile
+      integer, intent(in) :: LBi, UBi, LBj, UBj
+      integer, intent(in) :: IminS, ImaxS, JminS, JmaxS
+!
+!  Local variable declarations.
+!
+      logical :: Lprocess, SetBC
+      logical :: update = .FALSE.
+# if defined WET_DRY
+      logical :: bry_update
+# endif
+!
+      integer :: ILB, IUB, JLB, JUB
+      integer :: i, ic, itrc, j, k, my_tile
+!
+      real(r8) :: cff, cff1, cff2
+
+# include "set_bounds.h"
+!
+!  Lower and upper bounds for nontiled (global values) boundary arrays.
+!
+      my_tile=-1                           ! for global values
+      ILB=BOUNDS(ng)%LBi(my_tile)
+      IUB=BOUNDS(ng)%UBi(my_tile)
+      JLB=BOUNDS(ng)%LBj(my_tile)
+      JUB=BOUNDS(ng)%UBj(my_tile)
+!
+!=======================================================================
+!  Set point Sources/Sinks (river runoff).
+!=======================================================================
+!
+!  Point Source/Sink vertically integrated mass transport.
+!
+# ifdef ANA_PSOURCE
+      IF (LuvSrc(ng).or.LwSrc(ng).or.ANY(LtracerSrc(:,ng))) THEN
+        CALL ana_psource (ng, tile, iNLM)
+      END IF
+# else
+      IF (DOMAIN(ng)%SouthWest_Test(tile)) THEN
+        IF (LuvSrc(ng).or.LwSrc(ng)) THEN
+          CALL set_ngfld (ng, iNLM, idRtra, 1, Nsrc(ng), 1,             &
+     &                    1, Nsrc(ng), 1,                               &
+     &                    SOURCES(ng) % QbarG,                          &
+     &                    SOURCES(ng) % Qbar,                           &
+     &                    update)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+
+#  ifdef SOLVE3D
+          DO k=1,N(ng)
+            DO i=1,Nsrc(ng)
+              SOURCES(ng)%Qsrc(i,k)=SOURCES(ng)%Qbar(i)*                &
+     &                              SOURCES(ng)%Qshape(i,k)
+            END DO
+          END DO
+#  endif
+        END IF
+
+#  ifdef SOLVE3D
+!
+!  Tracer Sources/Sinks.
+!
+        DO itrc=1,NT(ng)
+          IF (LtracerSrc(itrc,ng)) THEN
+            CALL set_ngfld (ng, iNLM, idRtrc(itrc), 1, Nsrc(ng), N(ng), &
+     &                      1, Nsrc(ng), N(ng),                         &
+     &                      SOURCES(ng) % TsrcG(:,:,:,itrc),            &
+     &                      SOURCES(ng) % Tsrc(:,:,itrc),               &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+        END DO
+#  endif
+      END IF
+# endif
+!
+!=======================================================================
+!  Set forcing data.
+!=======================================================================
+!
+!  Set switch to process surface atmospheric fields.
+!
+# if defined FOUR_DVAR   && \
+     defined BULK_FLUXES && defined PRIOR_BULK_FLUXES
+!  In 4D-Var data assimilation applications, the user have the option
+!  to fix the prior (background phase) surface fluxes in the successive
+!  outer loops (Nouter>1) or the final analysis phase. In such case, the
+!  fluxes are read from the background trajector
+!
+      IF (Nrun.eq.1) THEN
+        Lprocess=.TRUE.
+      ELSE
+         Lprocess=.FALSE.
+      END IF
+# else
+      Lprocess=.TRUE.
+# endif
+
+# ifdef SOLVE3D
+
+#  ifdef CLOUDS
+!
+!  Set cloud fraction (nondimensional).  Notice that clouds are
+!  processed first in case that they are used to adjust shortwave
+!  radiation.
+!
+      IF (Lprocess) THEN
+#   ifdef ANA_CLOUD
+        CALL ana_cloud (ng, tile, iNLM)
+#   elif (defined FRC_COUPLING && defined TIME_INTERP) || \
+         !defined FRC_COUPLING
+        CALL set_2dfld_tile (ng, tile, iNLM, idCfra,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       FORCES(ng)%cloudG,                         &
+     &                       FORCES(ng)%cloud,                          &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+#   endif
+      END IF
+#  endif
+
+#  if defined BULK_FLUXES || defined ECOSIM  || \
+    (defined SHORTWAVE && defined ANA_SRFLUX && defined ALBEDO)
+!
+!  Set surface air temperature (degC).
+!
+      IF (Lprocess) THEN
+#   ifdef ANA_TAIR
+        CALL ana_tair (ng, tile, iNLM)
+#   elif (defined FRC_COUPLING && defined TIME_INTERP) || \
+         !defined FRC_COUPLING
+        CALL set_2dfld_tile (ng, tile, iNLM, idTair,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       FORCES(ng)%TairG,                          &
+     &                       FORCES(ng)%Tair,                           &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+#   endif
+      END IF
+#  endif
+
+#  if defined BULK_FLUXES || defined ECOSIM   || \
+     (defined SHORTWAVE && defined ANA_SRFLUX && defined ALBEDO)
+!
+!  Set surface air relative or specific humidity.
+!
+      IF (Lprocess) THEN
+#   ifdef ANA_HUMIDITY
+        CALL ana_humid (ng, tile, iNLM)
+#   elif (defined FRC_COUPLING && defined TIME_INTERP) || \
+         !defined FRC_COUPLING
+        CALL set_2dfld_tile (ng, tile, iNLM, idQair,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       FORCES(ng)%HairG,                          &
+     &                       FORCES(ng)%Hair,                           &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+#   endif
+      END IF
+#  endif
+
+#  ifdef SHORTWAVE
+!
+!  Set kinematic surface solar shortwave radiation flux (degC m/s).
+!
+#   ifdef ANA_SRFLUX
+      CALL ana_srflux (ng, tile, iNLM)
+#   elif (defined FRC_COUPLING && defined TIME_INTERP) || \
+         !defined FRC_COUPLING
+      CALL set_2dfld_tile (ng, tile, iNLM, idSrad,                      &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%srflxG,                           &
+     &                     FORCES(ng)%srflx,                            &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+#   endif
+
+#   ifdef DIURNAL_SRFLUX
+!
+!  Modulate the averaged shortwave radiation flux by the local diurnal
+!  cycle.
+!
+      CALL ana_srflux (ng, tile, iNLM)
+#   endif
+#  endif
+
+#  if defined RED_TIDE && defined DAILY_SHORTWAVE
+!
+!  Set kinematic daily-averaged surface solar shortwave radiation flux
+!  (degC m/s).
+!
+      CALL set_2dfld_tile (ng, tile, iNLM, idAsrf,                      &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%srflxG_avg,                       &
+     &                     FORCES(ng)%srflx_avg,                        &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+#  endif
+
+#  if defined BULK_FLUXES     && \
+    !(defined LONGWAVE        || defined LONGWAVE_OUT) && \
+     ( (defined FRC_COUPLING  && defined TIME_INTERP)  || \
+       !defined FRC_COUPLING )
+!
+!  Surface net longwave radiation (degC m/s).
+!
+      IF (Lprocess) THEN
+        CALL set_2dfld_tile (ng, tile, iNLM, idLrad,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       FORCES(ng)%lrflxG,                         &
+     &                       FORCES(ng)%lrflx,                          &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+#  endif
+
+#  if defined LONGWAVE_OUT   && defined BULK_FLUXES  && \
+     ( (defined FRC_COUPLING && defined TIME_INTERP) || \
+       !defined FRC_COUPLING )
+!
+!  Surface downwelling longwave radiation (degC m/s).
+!
+      IF (Lprocess) THEN
+        CALL set_2dfld_tile (ng, tile, iNLM, idLdwn,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       FORCES(ng)%lrflxG,                         &
+     &                       FORCES(ng)%lrflx,                          &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+#  endif
+
+#  if defined BULK_FLUXES || defined ECOSIM
+!
+!  Set surface winds (m/s).
+!
+      IF (Lprocess) THEN
+#   ifdef ANA_WINDS
+        CALL ana_winds (ng, tile, iNLM)
+#   elif (defined FRC_COUPLING && defined TIME_INTERP) || \
+         !defined FRC_COUPLING
+        CALL set_2dfld_tile (ng, tile, iNLM, idUair,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       FORCES(ng)%UwindG,                         &
+     &                       FORCES(ng)%Uwind,                          &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+!
+        CALL set_2dfld_tile (ng, tile, iNLM, idVair,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       FORCES(ng)%VwindG,                         &
+     &                       FORCES(ng)%Vwind,                          &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+
+#    ifdef CURVGRID
+!
+!  If input point surface winds or interpolated from coarse data, rotate
+!  to curvilinear grid.
+!
+        IF (.not.Linfo(1,idUair,ng).or.                                 &
+     &      (Iinfo(5,idUair,ng).ne.Lm(ng)+2).or.                        &
+     &      (Iinfo(6,idUair,ng).ne.Mm(ng)+2)) THEN
+          DO j=JstrR,JendR
+            DO i=IstrR,IendR
+              cff1=FORCES(ng)%Uwind(i,j)*GRID(ng)%CosAngler(i,j)+       &
+     &             FORCES(ng)%Vwind(i,j)*GRID(ng)%SinAngler(i,j)
+              cff2=FORCES(ng)%Vwind(i,j)*GRID(ng)%CosAngler(i,j)-       &
+     &             FORCES(ng)%Uwind(i,j)*GRID(ng)%SinAngler(i,j)
+              FORCES(ng)%Uwind(i,j)=cff1
+              FORCES(ng)%Vwind(i,j)=cff2
+            END DO
+          END DO
+
+          IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
+            CALL exchange_r2d_tile (ng, tile,                           &
+     &                              LBi, UBi, LBj, UBj,                 &
+     &                              FORCES(ng)%UWind)
+            CALL exchange_r2d_tile (ng, tile,                           &
+     &                              LBi, UBi, LBj, UBj,                 &
+     &                              FORCES(ng)%VWind)
+          END IF
+
+#     ifdef DISTRIBUTE
+          CALL mp_exchange2d (ng, tile, iNLM, 2,                        &
+     &                        LBi, UBi, LBj, UBj,                       &
+     &                        NghostPoints,                             &
+     &                        EWperiodic(ng), NSperiodic(ng),           &
+     &                        FORCES(ng)%UWind,                         &
+     &                        FORCES(ng)%VWind)
+#     endif
+        END IF
+#    endif
+#   endif
+      END IF
+#  endif
+
+#  ifdef BULK_FLUXES
+!
+!  Set rain fall rate (kg/m2/s).
+!
+      IF (Lprocess) THEN
+#   ifdef ANA_RAIN
+        CALL ana_rain (ng, tile, iNLM)
+#   elif (defined FRC_COUPLING && defined TIME_INTERP) || \
+         !defined FRC_COUPLING
+        CALL set_2dfld_tile (ng, tile, iNLM, idrain,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       FORCES(ng)%rainG,                          &
+     &                       FORCES(ng)%rain,                           &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+#   endif
+      END IF
+#  endif
+
+#  ifndef BULK_FLUXES
+!
+!  Set kinematic surface net heat flux (degC m/s).
+!
+#   ifdef ANA_STFLUX
+      CALL ana_stflux (ng, tile, iNLM, itemp)
+#   elif (defined FRC_COUPLING && defined TIME_INTERP) || \
+         !defined FRC_COUPLING
+      CALL set_2dfld_tile (ng, tile, iNLM, idTsur(itemp),               &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%stfluxG(:,:,:,itemp),             &
+     &                     FORCES(ng)%stflux (:,:,itemp),               &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+#   endif
+#  endif
+
+#  ifdef QCORRECTION
+!
+!  Set sea surface temperature (SST) and heat flux sensitivity to
+!  SST (dQdSST) which are used for surface heat flux correction.
+!
+#   ifdef ANA_SST
+      CALL ana_sst (ng, tile, iNLM)
+#   else
+      CALL set_2dfld_tile (ng, tile, iNLM, idSSTc,                      &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%sstG,                             &
+     &                     FORCES(ng)%sst,                              &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+#   endif
+!
+#   ifdef ANA_DQDSST
+      CALL ana_dqdsst (ng, tile, iNLM)
+#   else
+      CALL set_2dfld_tile (ng, tile, iNLM, iddQdT,                      &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%dqdtG,                            &
+     &                     FORCES(ng)%dqdt,                             &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+#   endif
+#  endif
+!
+!  Set kinematic bottom net heat flux (degC m/s).
+!
+#  ifdef ANA_BTFLUX
+      CALL ana_btflux (ng, tile, iNLM, itemp)
+#  else
+      CALL set_2dfld_tile (ng, tile, iNLM, idTbot(itemp),               &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%btfluxG(:,:,:,itemp),             &
+     &                     FORCES(ng)%btflux (:,:,itemp),               &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+#  endif
+
+#  ifdef SALINITY
+#   ifdef ANA_SSFLUX
+!
+!  Surface freshwater (E-P) flux (m/s) from analytical function.
+!
+      CALL ana_stflux (ng, tile, iNLM, isalt)
+#   else
+
+#    if !(defined BULK_FLUXES  || defined EMINUSP      || \
+          defined FRC_COUPLING)
+!
+!  Surface freshwater (E-P) flux (m/s) from NetCDF variable "swflux".
+!
+      CALL set_2dfld_tile (ng, tile, iNLM, idsfwf,                      &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%stfluxG(:,:,:,isalt),             &
+     &                     FORCES(ng)%stflux (:,:,isalt),               &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+
+#    elif defined BULK_FLUXES  && !defined EMINUSP
+!
+!  Surface freshwater (E-P) flux (m/s) from NetCDF variable "EminusP".
+!
+      IF (Lprocess) THEN
+        CALL set_2dfld_tile (ng, tile, iNLM, idEmPf,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       FORCES(ng)%stfluxG(:,:,:,isalt),           &
+     &                       FORCES(ng)%stflux (:,:,isalt),             &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+      END IF
+#    endif
+#   endif
+
+#   if defined SCORRECTION || defined SRELAXATION
+!
+!  Set surface salinity for freshwater flux correction.
+!
+#    ifdef ANA_SSS
+      CALL ana_sss (ng, tile, iNLM)
+#    else
+      CALL set_2dfld_tile (ng, tile, iNLM, idSSSc,                      &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%sssG,                             &
+     &                     FORCES(ng)%sss,                              &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+#    endif
+#   endif
+!
+!  Set kinematic bottom salt flux (m/s).
+!
+#   ifdef ANA_BSFLUX
+      CALL ana_btflux (ng, tile, iNLM, isalt)
+#   else
+      CALL set_2dfld_tile (ng, tile, iNLM, idTbot(isalt),               &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%btfluxG(:,:,:,isalt),             &
+     &                     FORCES(ng)%btflux (:,:,isalt),               &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+#   endif
+#  endif
+
+#  if defined BIOLOGY || defined SEDIMENT || defined T_PASSIVE
+!
+!  Set kinematic surface and bottom passive tracer fluxes (T m/s).
+!
+      DO itrc=NAT+1,NT(ng)
+#   ifdef ANA_SPFLUX
+        CALL ana_stflux (ng, tile, iNLM, itrc)
+#   else
+        CALL set_2dfld_tile (ng, tile, iNLM, idTsur(itrc),              &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       FORCES(ng)%stfluxG(:,:,:,itrc),            &
+     &                       FORCES(ng)%stflux (:,:,itrc),              &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+#   endif
+#   ifdef ANA_BPFLUX
+        CALL ana_btflux (ng, tile, iNLM, itrc)
+#   else
+        CALL set_2dfld_tile (ng, tile, iNLM, idTbot(itrc),              &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       FORCES(ng)%btfluxG(:,:,:,itrc),            &
+     &                       FORCES(ng)%btflux (:,:,itrc),              &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+#   endif
+      END DO
+#  endif
+# endif
+
+# if !defined BULK_FLUXES || defined READ_STRESS
+!
+!  Set kinematic surface momentum flux (m2/s2).
+!
+#  ifdef ANA_SMFLUX
+      CALL ana_smflux (ng, tile, iNLM)
+#  elif (defined FRC_COUPLING && defined TIME_INTERP) || \
+        !defined FRC_COUPLING
+      CALL set_2dfld_tile (ng, tile, iNLM, idUsms,                      &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%sustrG,                           &
+     &                     FORCES(ng)%sustr,                            &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+!
+      CALL set_2dfld_tile (ng, tile, iNLM, idVsms,                      &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%svstrG,                           &
+     &                     FORCES(ng)%svstr,                            &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+
+#   ifdef CURVGRID
+!
+!  If input point wind stress, rotate to curvilinear grid.  Notice
+!  that rotation is done at RHO-points. It does not matter.
+!
+      IF (.not.Linfo(1,idUsms,ng).or.                                   &
+     &    (Iinfo(5,idUsms,ng).ne.Lm(ng)+1).or.                          &
+     &    (Iinfo(6,idUsms,ng).ne.Mm(ng)+2)) THEN
+        DO j=JstrR,JendR
+          DO i=IstrR,IendR
+            cff1=FORCES(ng)%sustr(i,j)*GRID(ng)%CosAngler(i,j)+         &
+     &           FORCES(ng)%svstr(i,j)*GRID(ng)%SinAngler(i,j)
+            cff2=FORCES(ng)%svstr(i,j)*GRID(ng)%CosAngler(i,j)-         &
+     &           FORCES(ng)%sustr(i,j)*GRID(ng)%SinAngler(i,j)
+            FORCES(ng)%sustr(i,j)=cff1
+            FORCES(ng)%svstr(i,j)=cff2
+          END DO
+        END DO
+
+        IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
+          CALL exchange_u2d_tile (ng, tile,                             &
+     &                            LBi, UBi, LBj, UBj,                   &
+     &                            FORCES(ng)%sustr)
+          CALL exchange_v2d_tile (ng, tile,                             &
+     &                            LBi, UBi, LBj, UBj,                   &
+     &                            FORCES(ng)%svstr)
+        END IF
+
+#    ifdef DISTRIBUTE
+        CALL mp_exchange2d (ng, tile, iNLM, 2,                          &
+     &                      LBi, UBi, LBj, UBj,                         &
+     &                      NghostPoints,                               &
+     &                      EWperiodic(ng), NSperiodic(ng),             &
+     &                      FORCES(ng)%sustr,                           &
+     &                      FORCES(ng)%svstr)
+#    endif
+      END IF
+#   endif
+#  endif
+# endif
+
+# if defined BULK_FLUXES || defined ECOSIM || defined ATM_PRESS
+!
+!  Set surface air pressure (mb).
+!
+      IF (Lprocess) THEN
+#  ifdef ANA_PAIR
+        CALL ana_pair (ng, tile, iNLM)
+#  elif (defined FRC_COUPLING && defined TIME_INTERP) || \
+        !defined FRC_COUPLING
+        SetBC=.TRUE.
+!       SetBC=.FALSE.
+        CALL set_2dfld_tile (ng, tile, iNLM, idPair,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       FORCES(ng)%PairG,                          &
+     &                       FORCES(ng)%Pair,                           &
+     &                       update, SetBC)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+#  endif
+      END IF
+# endif
+
+# ifdef WAVE_DATA
+!
+!  Set surface wind-induced wave properties.
+!
+#  ifdef ANA_WWAVE
+      CALL ana_wwave (ng, tile, iNLM)
+#  else
+#   ifdef WAVES_DIR
+      CALL set_2dfld_tile (ng, tile, iNLM, idWdir,                      &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%DwaveG,                           &
+     &                     FORCES(ng)%Dwave,                            &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+
+#    ifdef CURVGRID
+!
+!  If input point-data, rotate direction to curvilinear coordinates.
+!
+      IF (.not.Linfo(1,idWdir,ng).or.                                   &
+     &    (Iinfo(5,idWdir,ng).ne.Lm(ng)+2).or.                          &
+     &    (Iinfo(6,idWdir,ng).ne.Mm(ng)+2)) THEN
+        DO j=JstrR,JendR
+          DO i=IstrR,IendR
+            FORCES(ng)%Dwave(i,j)=FORCES(ng)%Dwave(i,j)-                &
+     &                            GRID(ng)%angler(i,j)
+          END DO
+        END DO
+      END IF
+
+      IF (EWperiodic(ng).or.NSperiodic(ng)) THEN
+        CALL exchange_r2d_tile (ng, tile,                               &
+     &                          LBi, UBi, LBj, UBj,                     &
+     &                          FORCES(ng)%Dwave)
+      END IF
+
+#     ifdef DISTRIBUTE
+      CALL mp_exchange2d (ng, tile, iNLM, 1,                            &
+     &                    LBi, UBi, LBj, UBj,                           &
+     &                    NghostPoints,                                 &
+     &                    EWperiodic(ng), NSperiodic(ng),               &
+     &                    FORCES(ng)%Dwave)
+#     endif
+#    endif
+!
+#   endif
+
+#   ifdef WAVES_HEIGHT
+      CALL set_2dfld_tile (ng, tile, iNLM, idWamp,                      &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%HwaveG,                           &
+     &                     FORCES(ng)%Hwave,                            &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+!
+#   endif
+
+#   ifdef WAVES_LENGTH
+      CALL set_2dfld_tile (ng, tile, iNLM, idWlen,                      &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%LwaveG,                           &
+     &                     FORCES(ng)%Lwave,                            &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+!
+#   endif
+
+#   ifdef WAVES_TOP_PERIOD
+      CALL set_2dfld_tile (ng, tile, iNLM, idWptp,                      &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%Pwave_topG,                       &
+     &                     FORCES(ng)%Pwave_top,                        &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+!
+#   endif
+
+#   ifdef WAVES_BOT_PERIOD
+      CALL set_2dfld_tile (ng, tile, iNLM, idWpbt,                      &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%Pwave_botG,                       &
+     &                     FORCES(ng)%Pwave_bot,                        &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+!
+#   endif
+
+#   if defined WAVES_UB
+      CALL set_2dfld_tile (ng, tile, iNLM, idWorb,                      &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%Ub_swanG,                         &
+     &                     FORCES(ng)%Ub_swan,                          &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+!
+#   endif
+
+#   if defined TKE_WAVEDISS
+      CALL set_2dfld_tile (ng, tile, iNLM, idWdis,                      &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%Wave_dissipG,                     &
+     &                     FORCES(ng)%Wave_dissip,                      &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+!
+#   endif
+
+#   if defined SVENDSEN_ROLLER
+      CALL set_2dfld_tile (ng, tile, iNLM, idWbrk,                      &
+     &                     LBi, UBi, LBj, UBj,                          &
+     &                     FORCES(ng)%Wave_breakG,                      &
+     &                     FORCES(ng)%Wave_break,                       &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+#   endif
+#  endif
+# endif
+
+# if defined ECOSIM && defined SOLVE3D
+!
+!  Compute spectral irradiance and cosine of average zenith angle of
+!  downwelling spectral photons.
+!
+      CALL ana_specir (ng, tile, iNLM)
+# endif
+
+# ifdef ANA_SPINNING
+!
+!  Set time-varying rotation force (centripetal accelerations) for
+!  polar coordinate grids.
+!
+      CALL ana_spinning (ng, tile, iNLM)
+# endif
+
+# ifdef HYPOXIA_SRM
+!
+!  Total respiration rate for hypoxia.
+!
+#  ifdef ANA_RESPIRATION
+      CALL ana_respiration (ng, tile, iNLM)
+#  else
+      CALL set_3dfld_tile (ng, tile, iNLM, idResR,                      &
+     &                     LBi, UBi, LBj, UBj, 1, N(ng),                &
+     &                     OCEAN(ng)%respirationG,                      &
+     &                     OCEAN(ng)%respiration,                       &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+#  endif
+# endif
+
+# ifdef RED_TIDE
+!
+!  Red tide Observed Dissolved Inorganic Nutrient.
+!
+      CALL set_3dfld_tile (ng, tile, iNLM, idODIN,                      &
+     &                     LBi, UBi, LBj, UBj, 1, N(ng),                &
+     &                     OCEAN(ng)%DIN_obsG,                          &
+     &                     OCEAN(ng)%DIN_obs,                           &
+     &                     update)
+      IF (FoundError(exit_flag, NoError, __LINE__,                      &
+     &               __FILE__)) RETURN
+# endif
+
+#if defined FOUR_DVAR   && \
+    defined BULK_FLUXES && defined PRIOR_BULK_FLUXES
+!
+!=======================================================================
+!  In 4D-Var data assimilation algorithms, the user has the option to
+!  impose the prior (background phase) surface fluxes in the successive
+!  outer loops (Nouter>1) or the final analysis phase. Such fluxes were
+!  computed by routine "bulk_fluxes" and stored in the NLM background
+!  trajectory, BLK structure. Notice that "bulk_fluxes" is called in
+!  "main3d" only during the prior trajectory computation.
+!
+!  Therefore, the fluxes are time interpolated from the pior snapshots.
+!=======================================================================
+!
+      IF (.not.Lprocess) THEN
+!
+!  Set prior surface wind stress components.
+!
+        CALL set_2dfld_tile (ng, tile, iNLM, idUsms,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       FORCES(ng)%sustrG,                         &
+     &                       FORCES(ng)%sustr,                          &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+!
+        CALL set_2dfld_tile (ng, tile, iNLM, idVsms,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       FORCES(ng)%svstrG,                         &
+     &                       FORCES(ng)%svstr,                          &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+
+# ifdef ATM_PRESS
+!
+!  Set prior surface air pressure.
+!
+        SetBC=.TRUE.
+!!      SetBC=.FALSE.
+        CALL set_2dfld_tile (ng, tile, iNLM, idPair,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       FORCES(ng)%PairG,                          &
+     &                       FORCES(ng)%Pair,                           &
+     &                       update, SetBC)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+# endif
+
+# ifdef SOLVE3D
+#  ifndef ANA_STFLUX
+!
+!  Set prior surface net heat flux.
+!
+        CALL set_2dfld_tile (ng, tile, iNLM, idTsur(itemp),             &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       FORCES(ng)%stfluxG(:,:,:,itemp),           &
+     &                       FORCES(ng)%stflux (:,:,itemp),             &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+#  endif
+
+#  if defined SALINITY && !defined ANA_SSFLUX
+!
+!  Set prior surface freshwater flux.
+!
+        CALL set_2dfld_tile (ng, tile, iNLM, idEmPf,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       FORCES(ng)%stfluxG(:,:,:,isalt),           &
+     &                       FORCES(ng)%stflux (:,:,isalt),             &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+#  endif
+# endif
+      END IF
+#endif
+!
+!=======================================================================
+!  Set open boundary conditions fields.
+!=======================================================================
+!
+!  Set free-surface open boundary conditions.
+!
+      IF (LprocessOBC(ng)) THEN
+# ifdef ANA_FSOBC
+        CALL ana_fsobc (ng, tile, iNLM)
+# else
+        IF (DOMAIN(ng)%SouthWest_Test(tile)) THEN
+          IF (LBC(iwest,isFsur,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idZbry(iwest), JLB, JUB, 1,       &
+     &                      0, Mm(ng)+1, 1,                             &
+     &                      BOUNDARY(ng) % zetaG_west,                  &
+     &                      BOUNDARY(ng) % zeta_west,                   &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+!
+          IF (LBC(ieast,isFsur,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idZbry(ieast), JLB, JUB, 1,       &
+     &                      0, Mm(ng)+1, 1,                             &
+     &                      BOUNDARY(ng) % zetaG_east,                  &
+     &                      BOUNDARY(ng) % zeta_east,                   &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+!
+          IF (LBC(isouth,isFsur,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idZbry(isouth), ILB, IUB, 1,      &
+     &                      0, Lm(ng)+1 ,1,                             &
+     &                      BOUNDARY(ng) % zetaG_south,                 &
+     &                      BOUNDARY(ng) % zeta_south,                  &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+!
+          IF (LBC(inorth,isFsur,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idZbry(inorth), ILB, IUB, 1,      &
+     &                      0, Lm(ng)+1, 1,                             &
+     &                      BOUNDARY(ng) % zetaG_north,                 &
+     &                      BOUNDARY(ng) % zeta_north,                  &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+        END IF
+# endif
+
+# if defined WET_DRY
+!
+!  Ensure that water level on boundary cells is above bed elevation.
+!
+        IF (LBC(iwest,isFsur,ng)%acquire) THEN
+          bry_update=.FALSE.
+          IF (DOMAIN(ng)%Western_Edge(tile)) THEN
+            DO j=JstrR,JendR
+              cff=Dcrit(ng)-GRID(ng)%h(0,j)
+              IF (BOUNDARY(ng)%zeta_west(j).le.cff) THEN
+                BOUNDARY(ng)%zeta_west(j)=cff
+              END IF
+            END DO
+            bry_update=.TRUE.
+          END IF
+#  ifdef DISTRIBUTE
+          CALL mp_boundary (ng, iNLM, JstrR, JendR, JLB, JUB, 1, 1,     &
+     &                      bry_update,                                 &
+     &                      BOUNDARY(ng)%zeta_west)
+#  endif
+        END IF
+!
+        IF (LBC(ieast,isFsur,ng)%acquire) THEN
+          bry_update=.FALSE.
+          IF (DOMAIN(ng)%Eastern_Edge(tile)) THEN
+            DO j=JstrR,JendR
+              cff=Dcrit(ng)-GRID(ng)%h(Lm(ng)+1,j)
+              IF (BOUNDARY(ng)%zeta_east(j).le.cff) THEN
+                BOUNDARY(ng)%zeta_east(j)=cff
+              END IF
+            END DO
+            bry_update=.TRUE.
+          END IF
+#  ifdef DISTRIBUTE
+          CALL mp_boundary (ng, iNLM, JstrR, JendR, JLB, JUB, 1, 1,     &
+     &                      bry_update,                                 &
+     &                      BOUNDARY(ng)%zeta_east)
+#  endif
+        END IF
+!
+        IF (LBC(isouth,isFsur,ng)%acquire) THEN
+          bry_update=.FALSE.
+          IF (DOMAIN(ng)%Southern_Edge(tile)) THEN
+            DO i=IstrR,IendR
+              cff=Dcrit(ng)-GRID(ng)%h(i,0)
+              IF (BOUNDARY(ng)%zeta_south(i).le.cff) THEN
+                BOUNDARY(ng)%zeta_south(i)=cff
+              END IF
+            END DO
+            bry_update=.TRUE.
+          END IF
+#  ifdef DISTRIBUTE
+          CALL mp_boundary (ng, iNLM, IstrR, IendR, ILB, IUB, 1, 1,     &
+     &                      bry_update,                                 &
+     &                      BOUNDARY(ng)%zeta_south)
+#  endif
+        END IF
+!
+        IF (LBC(inorth,isFsur,ng)%acquire) THEN
+          bry_update=.FALSE.
+          IF (DOMAIN(ng)%Northern_Edge(tile)) THEN
+            DO i=IstrR,IendR
+              cff=Dcrit(ng)-GRID(ng)%h(i,Mm(ng)+1)
+              IF (BOUNDARY(ng)%zeta_north(i).le.cff) THEN
+                BOUNDARY(ng)%zeta_north(i)=cff
+              END IF
+            END DO
+            bry_update=.TRUE.
+          END IF
+#  ifdef DISTRIBUTE
+          CALL mp_boundary (ng, iNLM, IstrR, IendR, ILB, IUB, 1, 1,     &
+     &                      bry_update,                                 &
+     &                      BOUNDARY(ng)%zeta_north)
+#  endif
+        END IF
+# endif
+      END IF
+!
+!  Set 2D momentum component open boundary conditions.
+!
+      IF (LprocessOBC(ng)) THEN
+# ifdef ANA_M2OBC
+        CALL ana_m2obc (ng, tile, iNLM)
+# else
+        IF (DOMAIN(ng)%SouthWest_Test(tile)) THEN
+          IF (LBC(iwest,isUbar,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idU2bc(iwest), JLB, JUB, 1,       &
+     &                      0, Mm(ng)+1, 1,                             &
+     &                      BOUNDARY(ng) % ubarG_west,                  &
+     &                      BOUNDARY(ng) % ubar_west,                   &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+!
+          IF (LBC(iwest,isVbar,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idV2bc(iwest), JLB, JUB, 1,       &
+     &                      1, Mm(ng)+1, 1,                             &
+     &                      BOUNDARY(ng) % vbarG_west,                  &
+     &                      BOUNDARY(ng) % vbar_west,                   &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+!
+          IF (LBC(ieast,isUbar,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idU2bc(ieast), JLB, JUB, 1,       &
+     &                      0, Mm(ng)+1, 1,                             &
+     &                      BOUNDARY(ng) % ubarG_east,                  &
+     &                      BOUNDARY(ng) % ubar_east,                   &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+!
+          IF (LBC(ieast,isVbar,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idV2bc(ieast), JLB, JUB, 1,       &
+     &                      1, Mm(ng)+1, 1,                             &
+     &                      BOUNDARY(ng) % vbarG_east,                  &
+     &                      BOUNDARY(ng) % vbar_east,                   &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+!
+          IF (LBC(isouth,isUbar,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idU2bc(isouth), ILB, IUB, 1,      &
+     &                      1, Lm(ng)+1, 1,                             &
+     &                      BOUNDARY(ng) % ubarG_south,                 &
+     &                      BOUNDARY(ng) % ubar_south,                  &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+!
+          IF (LBC(isouth,isVbar,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idV2bc(isouth), ILB, IUB, 1,      &
+     &                      0, Lm(ng)+1, 1,                             &
+     &                      BOUNDARY(ng) % vbarG_south,                 &
+     &                      BOUNDARY(ng) % vbar_south,                  &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+!
+          IF (LBC(inorth,isUbar,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idU2bc(inorth), ILB, IUB, 1,      &
+     &                      1, Lm(ng)+1, 1,                             &
+     &                      BOUNDARY(ng) % ubarG_north,                 &
+     &                      BOUNDARY(ng) % ubar_north,                  &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+!
+          IF (LBC(inorth,isVbar,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idV2bc(inorth), ILB, IUB, 1,      &
+     &                      0, Lm(ng)+1, 1,                             &
+     &                      BOUNDARY(ng) % vbarG_north,                 &
+     &                      BOUNDARY(ng) % vbar_north,                  &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+        END IF
+# endif
+      END IF
+
+# ifdef SOLVE3D
+!
+!  Set 3D momentum components open boundary conditions.
+!
+      IF (LprocessOBC(ng)) THEN
+#  ifdef ANA_M3OBC
+        CALL ana_m3obc (ng, tile, iNLM)
+#  else
+        IF (DOMAIN(ng)%SouthWest_Test(tile)) THEN
+          IF (LBC(iwest,isUvel,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idU3bc(iwest), JLB, JUB, N(ng),   &
+     &                      0, Mm(ng)+1, N(ng),                         &
+     &                      BOUNDARY(ng) % uG_west,                     &
+     &                      BOUNDARY(ng) % u_west,                      &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+!
+          IF (LBC(iwest,isVvel,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idV3bc(iwest), JLB, JUB, N(ng),   &
+     &                      1, Mm(ng)+1, N(ng),                         &
+     &                      BOUNDARY(ng) % vG_west,                     &
+     &                      BOUNDARY(ng) % v_west,                      &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+!
+          IF (LBC(ieast,isUvel,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idU3bc(ieast), JLB, JUB, N(ng),   &
+     &                      0, Mm(ng)+1, N(ng),                         &
+     &                      BOUNDARY(ng) % uG_east,                     &
+     &                      BOUNDARY(ng) % u_east,                      &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+!
+          IF (LBC(ieast,isVvel,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idV3bc(ieast), JLB, JUB, N(ng),   &
+     &                      1, Mm(ng)+1, N(ng),                         &
+     &                      BOUNDARY(ng) % vG_east,                     &
+     &                      BOUNDARY(ng) % v_east,                      &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+!
+          IF (LBC(isouth,isUvel,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idU3bc(isouth), ILB, IUB, N(ng),  &
+     &                      1, Lm(ng)+1, N(ng),                         &
+     &                      BOUNDARY(ng) % uG_south,                    &
+     &                      BOUNDARY(ng) % u_south,                     &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+!
+          IF (LBC(isouth,isVvel,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idV3bc(isouth), ILB, IUB, N(ng),  &
+     &                      0, Lm(ng)+1, N(ng),                         &
+     &                      BOUNDARY(ng) % vG_south,                    &
+     &                      BOUNDARY(ng) % v_south,                     &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+!
+          IF (LBC(inorth,isUvel,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idU3bc(inorth), ILB, IUB, N(ng),  &
+     &                      1, Lm(ng)+1, N(ng),                         &
+     &                      BOUNDARY(ng) % uG_north,                    &
+     &                      BOUNDARY(ng) % u_north,                     &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+!
+          IF (LBC(inorth,isVvel,ng)%acquire) THEN
+            CALL set_ngfld (ng, iNLM, idV3bc(inorth), ILB, IUB, N(ng),  &
+     &                      0, Lm(ng)+1, N(ng),                         &
+     &                      BOUNDARY(ng) % vG_north,                    &
+     &                      BOUNDARY(ng) % v_north,                     &
+     &                      update)
+            IF (FoundError(exit_flag, NoError, __LINE__,                &
+     &                     __FILE__)) RETURN
+          END IF
+        END IF
+#  endif
+      END IF
+!
+!  Set tracer variables open boundary conditions.
+!
+      IF (LprocessOBC(ng)) THEN
+#  ifdef ANA_TOBC
+        CALL ana_tobc (ng, tile, iNLM)
+#  else
+        IF (DOMAIN(ng)%SouthWest_Test(tile)) THEN
+           DO itrc=1,NT(ng)
+            IF (LBC(iwest,isTvar(itrc),ng)%acquire) THEN
+              CALL set_ngfld (ng, iNLM, idTbry(iwest,itrc),             &
+     &                        JLB, JUB, N(ng), 0, Mm(ng)+1, N(ng),      &
+     &                        BOUNDARY(ng) % tG_west(:,:,:,itrc),       &
+     &                        BOUNDARY(ng) % t_west(:,:,itrc),          &
+     &                        update)
+              IF (FoundError(exit_flag, NoError, __LINE__,              &
+     &                       __FILE__)) RETURN
+            END IF
+!
+            IF (LBC(ieast,isTvar(itrc),ng)%acquire) THEN
+              CALL set_ngfld (ng, iNLM, idTbry(ieast,itrc),             &
+     &                        JLB, JUB, N(ng), 0, Mm(ng)+1, N(ng),      &
+     &                        BOUNDARY(ng) % tG_east(:,:,:,itrc),       &
+     &                        BOUNDARY(ng) % t_east(:,:,itrc),          &
+     &                        update)
+              IF (FoundError(exit_flag, NoError, __LINE__,              &
+     &                       __FILE__)) RETURN
+            END IF
+!
+            IF (LBC(isouth,isTvar(itrc),ng)%acquire) THEN
+              CALL set_ngfld (ng, iNLM, idTbry(isouth,itrc),            &
+     &                        ILB, IUB, N(ng), 0, Lm(ng)+1, N(ng),      &
+     &                        BOUNDARY(ng) % tG_south(:,:,:,itrc),      &
+     &                        BOUNDARY(ng) % t_south(:,:,itrc),         &
+     &                        update)
+              IF (FoundError(exit_flag, NoError, __LINE__,              &
+     &                       __FILE__)) RETURN
+            END IF
+!
+            IF (LBC(inorth,isTvar(itrc),ng)%acquire) THEN
+              CALL set_ngfld (ng, iNLM, idTbry(inorth,itrc),            &
+     &                        ILB, IUB, N(ng), 0, Lm(ng)+1, N(ng),      &
+     &                        BOUNDARY(ng) % tG_north(:,:,:,itrc),      &
+     &                        BOUNDARY(ng) % t_north(:,:,itrc),         &
+     &                        update)
+              IF (FoundError(exit_flag, NoError, __LINE__,              &
+     &                       __FILE__)) RETURN
+            END IF
+          END DO
+        END IF
+#  endif
+      END IF
+# endif
+!
+!=======================================================================
+!  Set climatology data.
+!=====================================================================
+!
+!  Set sea surface height climatology (m).
+!
+      IF (LsshCLM(ng)) THEN
+# ifdef ANA_SSH
+        CALL ana_ssh (ng, tile, iNLM)
+# else
+        CALL set_2dfld_tile (ng, tile, iNLM, idSSHc,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       CLIMA(ng)%sshG,                            &
+     &                       CLIMA(ng)%ssh,                             &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+# endif
+      END IF
+!
+!  Set 2D momentum components climatology (m/s).
+!
+      IF (Lm2CLM(ng)) THEN
+# ifdef ANA_M2CLIMA
+        CALL ana_m2clima (ng, tile, iNLM)
+# else
+        CALL set_2dfld_tile (ng, tile, iNLM, idUbcl,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       CLIMA(ng)%ubarclmG,                        &
+     &                       CLIMA(ng)%ubarclm,                         &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+!
+        CALL set_2dfld_tile (ng, tile, iNLM, idVbcl,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       CLIMA(ng)%vbarclmG,                        &
+     &                       CLIMA(ng)%vbarclm,                         &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+# endif
+      END IF
+
+# ifdef SOLVE3D
+!
+!  Set 3D momentum components climatology (m/s).
+!
+      IF (Lm3CLM(ng)) THEN
+#  ifdef ANA_M3CLIMA
+        CALL ana_m3clima (ng, tile, iNLM)
+#  else
+        CALL set_3dfld_tile (ng, tile, iNLM, idUclm,                    &
+     &                       LBi, UBi, LBj, UBj, 1, N(ng),              &
+     &                       CLIMA(ng)%uclmG,                           &
+     &                       CLIMA(ng)%uclm,                            &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+!
+        CALL set_3dfld_tile (ng, tile, iNLM, idVclm,                    &
+     &                       LBi, UBi, LBj, UBj, 1, N(ng),              &
+     &                       CLIMA(ng)%vclmG,                           &
+     &                       CLIMA(ng)%vclm,                            &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+#  endif
+      END IF
+!
+!  Set tracer variables climatology.
+!
+#  ifdef ANA_TCLIMA
+      IF (ANY(LtracerCLM(:,ng))) THEN
+        CALL ana_tclima (ng, tile, iNLM)
+      END IF
+#  else
+      ic=0
+      DO itrc=1,NT(ng)
+        IF (LtracerCLM(itrc,ng)) THEN
+          ic=ic+1
+          CALL set_3dfld_tile (ng, tile, iNLM, idTclm(itrc),            &
+     &                         LBi, UBi, LBj, UBj, 1, N(ng),            &
+     &                         CLIMA(ng)%tclmG(:,:,:,:,ic),             &
+     &                         CLIMA(ng)%tclm (:,:,:,ic),               &
+     &                         update)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END IF
+      END DO
+#  endif
+# endif
+
+# if defined NLM_OUTER                || \
+     defined RBL4DVAR                 || \
+     defined RBL4DVAR_ANA_SENSITIVITY || \
+     defined RBL4DVAR_FCT_SENSITIVITY || \
+     defined SP4DVAR
+!
+!=======================================================================
+!  Set weak contraint forcing.
+!=======================================================================
+!
+      IF (FrequentImpulse(ng)) THEN
+!
+!  Set free-surface forcing.
+!
+        CALL set_2dfld_tile (ng, tile, iNLM, idFsur,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       OCEAN(ng)%zetaG,                           &
+     &                       OCEAN(ng)%f_zeta,                          &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+
+#  ifndef SOLVE3D
+!
+!  Set 2D momentum forcing.
+!
+        CALL set_2dfld_tile (ng, tile, iNLM, idUbar,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       OCEAN(ng)%ubarG,                           &
+     &                       OCEAN(ng)%f_ubar,                          &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+
+        CALL set_2dfld_tile (ng, tile, iNLM, idVbar,                    &
+     &                       LBi, UBi, LBj, UBj,                        &
+     &                       OCEAN(ng)%vbarG,                           &
+     &                       OCEAN(ng)%f_vbar,                          &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+
+#  else
+!
+!  Set 3D momentum.
+!
+        CALL set_3dfld_tile (ng, tile, iNLM, idUvel,                    &
+     &                       LBi, UBi, LBj, UBj, 1, N(ng),              &
+     &                       OCEAN(ng)%uG,                              &
+     &                       OCEAN(ng)%f_u,                             &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+
+        CALL set_3dfld_tile (ng, tile, iNLM, idVvel,                    &
+     &                       LBi, UBi, LBj, UBj, 1, N(ng),              &
+     &                       OCEAN(ng)%vG,                              &
+     &                       OCEAN(ng)%f_v,                             &
+     &                       update)
+        IF (FoundError(exit_flag, NoError, __LINE__,                    &
+     &                 __FILE__)) RETURN
+!
+!  Set 3D tracers.
+!
+        DO itrc=1,NT(ng)
+          CALL set_3dfld_tile (ng, tile, iNLM, idTvar(itrc),            &
+     &                         LBi, UBi, LBj, UBj, 1, N(ng),            &
+     &                         OCEAN(ng)%tG(:,:,:,:,itrc),              &
+     &                         OCEAN(ng)%f_t(:,:,:,itrc),               &
+     &                         update)
+          IF (FoundError(exit_flag, NoError, __LINE__,                  &
+     &                   __FILE__)) RETURN
+        END DO
+#  endif
+      END IF
+# endif
+!
+      RETURN
+      END SUBROUTINE set_data_tile
+#else
+      SUBROUTINE set_data
+      RETURN
+      END SUBROUTINE set_data
+#endif


### PR DESCRIPTION
Changes to support reading of stress from forcing file(s) in ROMS svn version 1041. Is enabled by `#define READ_STRESS` in your CPP defs. With this option turned on, ROMS will search for `sustr` and `svstr` (defined in varinfo.dat) in the forcing file(s). If using this option in combination with `#define BULK_FLUXES`, ROMS will use the bulk flux scheme for all other fluxes besides the stress.

Code changes made by Pål Erik Isachsen (p.e.isachsen@geu.uio.no) and Johannes Röhrs (johannesro@met.no)