### PR TITLE
compile ROMS/CICE on R8 IB MET ppi

### DIFF
--- a/apps/common/modified_src/cice5.1.2/bld/Macros.Linux.MET_PPI
+++ b/apps/common/modified_src/cice5.1.2/bld/Macros.Linux.MET_PPI
@@ -17,7 +17,7 @@ endif
 FIXEDFLAGS := -132
 FREEFLAGS  := 
 # Should use this together with ROMS? 
-FFLAGS     :=  -xHost -mcmodel=large # -Nmpi
+FFLAGS     :=  -mcmodel=large # -xHost -Nmpi
 MOD_SUFFIX := mod
 LD         := $(FC)
 LDFLAGS    := $(FFLAGS) -v
@@ -40,8 +40,8 @@ endif
 
 ifeq ($(IO_TYPE), netcdf)
    CPPDEFS :=  $(CPPDEFS) -Dncdf
-   INCLDIR :=  $(INCLDIR) -I/modules/rhel8/user-apps/netcdf/4.6.0intel22-opa/include -I/modules/rhel8/user-apps/openmpi/3.1.4-opa-i22-2023/include
-   SLIBS   :=  $(SLIBS) -L/modules/rhel8/user-apps/openmpi/3.1.4-opa-i22-2023/lib  -L/modules/rhel8/user-apps/netcdf/4.6.0intel22-opa/lib -lnetcdf -lnetcdff -L/modules/rhel8/Compiler/HPC-Toolkit/2022/2022.3.1.16997/compiler/latest/linux/compiler/lib -L/modules/rhel8/user-apps/netcdf/4.6.0intel22-opa/lib -lhdf5_hl -lhdf5 -lsz -lz -lcurl -lm  #   -lhdf5_hl -lhdf5 -lsz -lz -lcurl -lm
+   INCLDIR :=  $(INCLDIR) -I/modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-i22-2023-prod/include -I/modules/rhel8/user-apps/openmpi/3.1.4-IB-i22-2023/include 
+   SLIBS   :=  $(SLIBS) -L/modules/rhel8/user-apps/openmpi/3.1.4-IB-i22-2023/lib -L/modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-i22-2023-prod/lib -lnetcdff -lnetcdf -L/modules/rhel8/Compiler/HPC-Toolkit/2022/2022.3.1.16997/compiler/latest/linux/compiler/lib -L/modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-i22-2023-prod/lib -lhdf5_hl -lhdf5 -lsz -lz -lm
 endif
 
 ifeq ($(compile_threaded), true) 

--- a/apps/modules.sh
+++ b/apps/modules.sh
@@ -16,12 +16,10 @@ elif [ "$METROMS_MYHOST" == "met_ppi" ]; then
     module load openmpi/3.1.4-intel2018
     module load nco/4.7.9-intel2018
   elif [ `lsb_release -sc` == 'Ootpa' ]; then
-    module use /modules/MET/rhel8/user-modules/
+    module use /modules/MET/rhel8/user-modules/ /modules/MET/rhel8/IT-modules
     module add compiler/Intel2022
     module add IB-R8-A/netcdf/4.6.1-IB-i22-2023
     module add IB-R8-A/openmpi/3.1.4-IB-i22-2023
-    #module add OPA-R8/netcdf/4.6.0intel22-opa OPA-R8/openmpi/3.1.4-i22-2023
-    #module load nco # ask nicob!! is in conda production env
   else
     echo "Undefined linux distro for met_ppi"
   fi


### PR DESCRIPTION
xHost flag removed in CICE macros MET_PPI file, added needed modules to run Barents-2.5 in R8 IB at MET ppi