### PR TITLE
Cice work load balance

### DIFF
--- a/apps/build_cice.sh
+++ b/apps/build_cice.sh
@@ -4,6 +4,7 @@ set -x
 export CICEVERSION=cice5.1.2
 
 NPX=1; NPY=1
+NBX=1; NBY=1
 if [ "${METROMS_MYHOST}" == "metlocal" ] || [ "${METROMS_MYHOST}" == "met_ppi" ]; then
     NPX=1  
     NPY=2
@@ -18,8 +19,8 @@ fi
 
 if [ $# -lt 1 ]
   then
-  echo "Usage: $0 modelname <xcpu> <ycpu>"
-  echo "<xcpu> <ycpu> are optional arguments"
+  echo "Usage: $0 modelname <xcpu> <ycpu> <xblk> <yblk>"
+  echo "<xcpu> <ycpu> and <xblk> <yblk> are optional arguments"
   exit
 fi
 export ROMS_APPLICATION=$1
@@ -29,7 +30,13 @@ if [ $# -ge 3 ]; then
     NPY=$3
 fi
 
-echo "NPX = $NPX, NPY = $NPY"
+if [ $# -ge 5 ]; then
+    NBX=$4
+    NBY=$5
+fi
+
+echo Number of processors: "NPX = $NPX, NPY = $NPY"
+echo Number of blocks per processor in each direction "NBX = $NBX, NBY = $NBY"
 
 #if [ $# -ne 2 ]
 #then
@@ -68,7 +75,7 @@ cp -av ${METROMS_APPDIR}/$ROMS_APPLICATION/cice_input_grid/* $CICE_DIR/input_tem
 rm -f $CICE_DIR/rundir/cice
 
 echo $PWD
-./comp_ice $ROMS_APPLICATION $NPX $NPY
+./comp_ice $ROMS_APPLICATION $NPX $NPY $NBX $NBY
 
 # Not working on nebula2 yet due to problems in the linking of stand-alone cice
 if [ ! "${METROMS_MYHOST}" == "nebula2" ]; then

--- a/apps/common/modified_src/cice5.1.2/comp_ice
+++ b/apps/common/modified_src/cice5.1.2/comp_ice
@@ -106,14 +106,13 @@ else
     ((NPY=0))
     ((BPX=1))
     ((BPY=1))
-    ((NPY=1))
     ((NTASK=NPX*NPY))
 fi
 ORES=$RES
 ((NPXO=NPX))
 ((NPYO=NPY))
-((BPXO=BPXO))
-((NPYO=BPYO))
+((BPXO=BPX))
+((NPYO=BPY))
 
 
 
@@ -299,8 +298,15 @@ if [ $comp -eq 1 ]; then
     $MAKE -j $ncomp VPFILE=Filepath EXEC=$EXEDIR/cice \
         NXGLOB=$NXGLOB NYGLOB=$NYGLOB \
         BLCKX=$BLCKX BLCKY=$BLCKY MXBLCKS=$MXBLCKS \
-	-f  $CBLD/Makefile MACFILE=$CBLD/Macros.$SITE || exit 2
+	-f  $CBLD/Makefile MACFILE=$CBLD/Macros.$SITE || err=1
+#	-f  $CBLD/Makefile MACFILE=$CBLD/Macros.$SITE || exit 2
 fi
+
+if [ $err -eq 1 ] && [ "$METROMS_MYHOST" != "nebula2" ] ; then
+    exit 2
+else
+    echo "Continue compile script on  $METROMS_MYHOST despite makefile error "
+fi  
 
 cd ..
 pwd                                         

--- a/apps/common/modified_src/cice5.1.2/source/ice_domain.F90
+++ b/apps/common/modified_src/cice5.1.2/source/ice_domain.F90
@@ -421,7 +421,8 @@
    where (nocn > 0)
      work_per_block = nocn/work_unit + 1
    elsewhere
-     work_per_block = 0
+!jd     work_per_block = 0
+     work_per_block = 1
    end where
    deallocate(nocn)
 

--- a/apps/common/modified_src/roms-trunk820/Linux-ifort.mk_nebula2
+++ b/apps/common/modified_src/roms-trunk820/Linux-ifort.mk_nebula2
@@ -92,7 +92,7 @@ ifdef USE_DEBUG
            CFLAGS += -g
          CXXFLAGS += -g
 else
-           FFLAGS += -ip -O3 
+           FFLAGS += -ip -O3 -xHost
 #           FFLAGS += -ip -O3 -g
            CFLAGS += -O3
          CXXFLAGS += -O3


### PR DESCRIPTION
Re-activated compile options for allowing more than one block (sub-domain) per mpi-task in CICE. This is done with the block functionality in CICE. 
ice_domain.F90 is changed to avoid the elimination of land-only blocks because this functionality caused problems with the coupling logic. 

This should allow for more efficient use of the processors allocated to cice by using the roundrobin or sectrobin distribution_type in the cice_in namelist file. 

In addition, small changes to the nebula2 compilation of cice and roms are included to allow efficient debuging (bound-checking in cice), and to increase speed of roms (-xHost)