### PR TITLE
Reduced log-information about freezing point option in ROMS

### DIFF
--- a/apps/common/modified_src/roms-trunk820/frazil_ice_prod_mod.F
+++ b/apps/common/modified_src/roms-trunk820/frazil_ice_prod_mod.F
@@ -1,4 +1,5 @@
 #include "cppdefs.h"
+!#define debug
       MODULE frazil_ice_prod_mod
 #if defined CICE_OCEAN
       use mod_kinds, only: r8
@@ -79,9 +80,10 @@
       CALL wclock_on (ng, iNLM, 44)
 # endif
 
+#ifdef debug      
       if (master) write(stdout,*)                                       &
      &     'frazil_ice_prod: Tfrz option ',trim(tfrz_option)
-      
+#endif      
 !
       CALL frazil_ice_prod_tile (ng, tile,                              &
      &                      LBi, UBi, LBj, UBj,                         &

--- a/apps/common/modified_src/roms-trunk820/ocean_coupler.F
+++ b/apps/common/modified_src/roms-trunk820/ocean_coupler.F
@@ -140,6 +140,7 @@
       USE mod_kinds
       USE mod_scalars
       USE mod_iounits, only: stdout
+      USE frazil_ice_prod_mod, only : tfrz_option
 
 ! 
 !  Imported variable definitions.
@@ -297,6 +298,11 @@
         deallocate (length)
       END IF
 
+      if (master) write(stdout,*)                                       &
+     &     'ROMS Ocean Coupler: Frazil ice production is calulated ',   &
+     &     'based on the ',trim(tfrz_option), 'Tfrz_option'
+
+      
 #ifdef PROFILE
       CALL wclock_off (ng, iNLM, 36)
 #endif


### PR DESCRIPTION
- Reduced output to the ROMS-logfile about which Trz_option is used. 
- Added documentation in the log-file written during initialization of the coupling only about the Tfrz_option
- The code should be bit-identical to last version