### PR TITLE
Updating netcdf and openmpi libraries 

### DIFF
--- a/apps/common/modified_src/cice5.1.2/bld/Macros.Linux.MET_PPI
+++ b/apps/common/modified_src/cice5.1.2/bld/Macros.Linux.MET_PPI
@@ -40,8 +40,8 @@ endif
 
 ifeq ($(IO_TYPE), netcdf)
    CPPDEFS :=  $(CPPDEFS) -Dncdf
-   INCLDIR :=  $(INCLDIR) -I/modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-i22-2023-prod/include -I/modules/rhel8/user-apps/openmpi/3.1.4-IB-i22-2023/include 
-   SLIBS   :=  $(SLIBS) -L/modules/rhel8/user-apps/openmpi/3.1.4-IB-i22-2023/lib -L/modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-i22-2023-prod/lib -lnetcdff -lnetcdf -L/modules/rhel8/Compiler/HPC-Toolkit/2022/2022.3.1.16997/compiler/latest/linux/compiler/lib -L/modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-i22-2023-prod/lib -lhdf5_hl -lhdf5 -lsz -lz -lm
+   INCLDIR :=  $(INCLDIR) -I/modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-i22-2024-prod/include -I/modules/rhel8/user-apps/openmpi/5.0.5-IB-i22-2024/include 
+   SLIBS   :=  $(SLIBS) -L/modules/rhel8/user-apps/openmpi/5.0.5-IB-i22-2024/lib -L/modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-i22-2024-prod/lib -lnetcdff -lnetcdf -L/modules/rhel8/Compiler/HPC-Toolkit/2022/2022.3.1.16997/compiler/latest/linux/compiler/lib -L/modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-i22-2023-prod/lib -lhdf5_hl -lhdf5 -lsz -lz -lm
 endif
 
 ifeq ($(compile_threaded), true) 

--- a/apps/common/modified_src/roms-trunk820/Linux-ifort.mk_met_ppi_rhel8
+++ b/apps/common/modified_src/roms-trunk820/Linux-ifort.mk_met_ppi_rhel8
@@ -44,12 +44,9 @@
 #
 
 ifdef USE_NETCDF4
-    #     NC_CONFIG ?= nc-config
-    # NETCDF_INCDIR ?= $(shell $(NC_CONFIG) --prefix)/include
-    #          LIBS := $(shell $(NC_CONFIG) --flibs)
-    NETCDF_INCDIR ?= /modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-i22-2023-prod/include
-    NETCDF_LIBDIR ?= /modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-i22-2023-prod/lib
-             LIBS := -L$(NETCDF_LIBDIR) -lnetcdff -lnetcdf
+        NC_CONFIG ?= nf-config
+    NETCDF_INCDIR ?= $(shell $(NC_CONFIG) --prefix)/include
+             LIBS := $(shell $(NC_CONFIG) --flibs)
 else
     # NETCDF_INCDIR ?= /modules/rhel8/user-apps/netcdf/4.6.0intel22-opa/include #/modules/rhel8/conda/install/envs/production-10-2022/include
     # NETCDF_LIBDIR ?= /modules/rhel8/user-apps/netcdf/4.6.0intel22-opa/lib #/modules/rhel8/conda/install/envs/production-10-2022/lib
@@ -68,7 +65,8 @@ endif
 ifdef USE_MPI
          CPPFLAGS += -DMPI
  ifdef USE_MPIF90
-               FC := mpifort
+               FC := mpifort  #/usr/mpi/gcc/openmpi-4.0.6-hfi/bin/mpifort
+	       #FC := /modules/rhel8/Compiler/HPC-Toolkit/2022/2022.3.1.16997/mpi/latest/bin/mpiifort
  else
              LIBS += -lfmpi-pgi -lmpi-pgi
  endif
@@ -80,11 +78,13 @@ ifdef USE_OpenMP
 endif
 
 ifdef USE_DEBUG
-           FFLAGS += -g -check bounds -traceback
-#           FFLAGS += -g -check bounds -traceback -check uninit -warn interfaces,nouncalled -gen-interfaces
-#           FFLAGS += -g -check uninit -ftrapuv -traceback
+#          FFLAGS += -g -check bounds -traceback
+           FFLAGS += -g -check bounds -traceback -check uninit -warn interfaces,nouncalled -gen-interfaces
+#          FFLAGS += -g -check uninit -ftrapuv -traceback
 else
-           FFLAGS += -ip -O3
+          #  FFLAGS += -ip -O3
+          # Edit 4.9.24
+           FFLAGS += -O3
 endif
 
 ifdef USE_MCT


### PR DESCRIPTION
Update in cice5.1.2 Macro file:
- netcdf library to netcdf/netcdf-4.6.1-IB-i22-2024-prod/lib
- openmpi library to openmpi/5.0.5-IB-i22-2024/lib

Update in roms-trunk820 Linux-ifort file:
- NC_CONFIG ?= nf-config