### PR TITLE
Modified time variable for initial condition file

### DIFF
--- a/apps/common/modified_src/cice5.1.2/drivers/cice/CICE_InitMod.F90
+++ b/apps/common/modified_src/cice5.1.2/drivers/cice/CICE_InitMod.F90
@@ -167,7 +167,12 @@
       call init_flux_atm        ! initialize atmosphere fluxes sent to coupler
       call init_flux_ocn        ! initialize ocean fluxes sent to coupler
 
-      if (write_ic) call accum_hist(dt) ! write initial conditions 
+      if (write_ic) then
+         !jbd manipulate time to get it similar to the initial time
+         time = time - dt
+         call accum_hist(dt) ! write initial conditions 
+         time = time + dt
+      end if
 
 !jd#ifdef ROMSCOUPLED
 !jd      call CICE_MCT_coupling


### PR DESCRIPTION
- The time variable are changed to be consistent with the start time of the model, and not dt later, when writing restart initial condition files. 
- Results should be bit-identical, except the time variable for the written initial condition file.

