### PR TITLE
Compile on PPI IB and load correct modules to run Barents-2.5 EPS

### DIFF
--- a/apps/common/modified_src/cice5.1.2/bld/Macros.Linux.MET_PPI
+++ b/apps/common/modified_src/cice5.1.2/bld/Macros.Linux.MET_PPI
@@ -8,7 +8,7 @@ ULIBS      :=
 CPP        := /usr/bin/cpp
 CPPFLAGS   := -P -traditional
 CPPDEFS    := -DLINUX
-CFLAGS     := -c -O2
+CFLAGS     := -c -O3
 ifeq ($(COMMDIR), mpi)
    FC         := mpif90
 else
@@ -17,7 +17,7 @@ endif
 FIXEDFLAGS := -132
 FREEFLAGS  := 
 # Should use this together with ROMS? 
-FFLAGS     :=  -mcmodel=large # -xHost -Nmpi
+FFLAGS     := -mcmodel=large -ip -O3 #-xHost -Nmpi
 MOD_SUFFIX := mod
 LD         := $(FC)
 LDFLAGS    := $(FFLAGS) -v
@@ -40,8 +40,8 @@ endif
 
 ifeq ($(IO_TYPE), netcdf)
    CPPDEFS :=  $(CPPDEFS) -Dncdf
-   INCLDIR :=  $(INCLDIR) -I/modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-i22-2024-prod/include -I/modules/rhel8/user-apps/openmpi/5.0.5-IB-i22-2024/include 
-   SLIBS   :=  $(SLIBS) -L/modules/rhel8/user-apps/openmpi/5.0.5-IB-i22-2024/lib -L/modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-i22-2024-prod/lib -lnetcdff -lnetcdf -L/modules/rhel8/Compiler/HPC-Toolkit/2022/2022.3.1.16997/compiler/latest/linux/compiler/lib -L/modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-i22-2023-prod/lib -lhdf5_hl -lhdf5 -lsz -lz -lm
+   INCLDIR :=  $(INCLDIR) -I/modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-ucx1.17-i22-2024-prod/include -I/modules/rhel8/user-apps/openmpi/5.0.5-IB-ucx1.17-i22-2024/include 
+   SLIBS   :=  $(SLIBS) -L/modules/rhel8/user-apps/openmpi/5.0.5-IB-ucx1.17-i22-2024/lib -L/modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-ucx1.17-i22-2024-prod/lib -lnetcdff -lnetcdf -L/modules/rhel8/Compiler/HPC-Toolkit/2022/2022.3.1.16997/compiler/latest/linux/compiler/lib -L/modules/rhel8/user-apps/netcdf/nnetcdf-4.6.1-IB-ucx1.17-i22-2024-prod/lib -lhdf5_hl -lhdf5 -lsz -lz -lm
 endif
 
 ifeq ($(compile_threaded), true) 
@@ -65,4 +65,3 @@ ifeq ($(IO_TYPE), pio)
 #   SLIBS   := $(SLIBS) -L/usr/projects/climate/SHARED_CLIMATE/software/conejo/intel_openmpi/netcdf-3.6.3/lib -lnetcdf
 
 endif
-

--- a/apps/common/modified_src/roms-trunk820/Linux-ifort.mk_met_ppi_rhel8
+++ b/apps/common/modified_src/roms-trunk820/Linux-ifort.mk_met_ppi_rhel8
@@ -24,8 +24,7 @@
 # First the defaults
 #
                FC := ifort
-           FFLAGS := -mcmodel=large
-          #  FFLAGS := -heap-arrays -fp-model precise
+           FFLAGS := -mcmodel=large -ip -O3 #-xHost -O3 -ip -O3 -march=core-avx2 (ifort) -heap-arrays -fp-model precise
               CPP := /usr/bin/cpp
          CPPFLAGS := -P -traditional
           LDFLAGS :=

--- a/apps/modules.sh
+++ b/apps/modules.sh
@@ -16,13 +16,28 @@ elif [ "$METROMS_MYHOST" == "met_ppi" ]; then
     module load openmpi/3.1.4-intel2018
     module load nco/4.7.9-intel2018
   elif [ `lsb_release -sc` == 'Ootpa' ]; then
-    module use /modules/MET/rhel8/user-modules/ /modules/MET/rhel8/IT-modules
-    # module add compiler/Intel2022
-    # module add IB-R8-A/netcdf/4.6.1-IB-i22-2023
-    # module add IB-R8-A/openmpi/3.1.4-IB-i22-2023
-    module add compiler/Intel2022
-    module add IB-R8-B/netcdf/4.6.1-IB-i22-2024
-    module add IB-R8-B/openmpi/5.0.5-IB-i22-2024
+    if [ "$METROMS_LOGINNODE" == "r8_a_ucx" ]; then
+      # add modules for IB A ib-dev-ucx1-17-a-r8.q queue
+      module use /modules/MET/rhel8/user-modules/ /modules/MET/rhel8/IT-modules
+      module add compiler/Intel2022
+      module add IB-R8-A/UCX1.17/netcdf/4.6.1-IB-ucx1.17-i22-2024
+      module add IB-R8-A/UCX1.17/openmpi/5.0.5-IB-ucx1.17-i22-2024
+      echo "Modules for" $METROMS_LOGINNODE "loaded"
+    elif [ "$METROMS_LOGINNODE" == "r8_a" ]; then
+      # add modules for IB A ib-dev-a-r8.q queue
+      module use /modules/MET/rhel8/user-modules/ /modules/MET/rhel8/IT-modules
+      module add compiler/Intel2022
+      module add IB-R8-B/netcdf/4.6.1-IB-i22-2024
+      module add IB-R8-B/openmpi/5.0.5-IB-i22-2024
+      echo "Modules for" $METROMS_LOGINNODE "loaded"
+    elif [ "$METROMS_LOGINNODE" == "r8_b" ]; then
+      # add modules for IB B
+      module use /modules/MET/rhel8/user-modules/ /modules/MET/rhel8/IT-modules
+      module add compiler/Intel2022
+      module add IB-R8-B/netcdf/4.6.1-IB-i22-2024
+      module add IB-R8-B/openmpi/5.0.5-IB-i22-2024
+      echo "Modules for" $METROMS_LOGINNODE "loaded"
+    fi
   else
     echo "Undefined linux distro for met_ppi"
   fi

--- a/apps/myenv.bash
+++ b/apps/myenv.bash
@@ -1,7 +1,30 @@
 #!/bin/bash
 
-export METROMS_MYHOST=$1
-echo "loading $METROMS_MYHOST paths"
+# Check if at least one argument was provided
+if [ $# -eq 0 ]; then
+    echo "Error: Please provide at least one argument."
+    exit 1
+fi
+# Always assign the first argument to METROMS_MYHOST
+METROMS_MYHOST=$1
+
+# If METROMS_MYHOST is met_ppi, check if second argument METROMS_LOGINNODE is provided
+if [ "$METROMS_MYHOST" == "met_ppi" ]; then
+    # Check if a second argument was provided
+    if [ $# -eq 2 ]; then
+        METROMS_LOGINNODE=$2
+    else
+        # If not, set the METROMS_LOGINNODE variable to r8_b for met_ppi
+        METROMS_LOGINNODE="r8_b"
+        echo "No login node option provided, loading $METROMS_LOGINNODE login node"
+    fi
+fi
+
+# Export the variables
+export METROMS_MYHOST
+export METROMS_LOGINNODE
+echo "Loading $METROMS_MYHOST paths"
+echo "Loading $METROMS_LOGINNODE login node if METROMS_MYHOST is met_ppi"
 
 if [ "$METROMS_MYHOST" == "met_ppi" ]; then
     if [ "$USER" == "havis" ]; then


### PR DESCRIPTION
1. myenv.bash
- if met_ppi option is used, a second input is needed: r8_a, r8_a_ucx, r8_b in order to load the correct modules for a specific IB queue

2. modules.sh
- load correct modules depending on the keyword coming from the myenv.bash input (e.g. source myenv.bash met_ppi r8_a)
- if no second keyword was provided, default is set to r8_b and modules for IB B are loaded

3. Macros for ROMS (roms-trunk-820: Linux-ifort.mk_met_ppi_rhel8) and CICE (cice.5.1.2/bld: Macros.Linux.MET_PPI)
- changed FFLAGS to -mcmodel=large -ip -O3
- added correct path to netcdf and openmpi libraries in ucx-a queue (in cice.5.1.2/bld: Macros.Linux.MET_PPI), ROMS Macros reads them automatically depending on the queue it is compiled