### PR TITLE
Add modules for IB B UCX queue

### DIFF
--- a/apps/common/modified_src/cice5.1.2/bld/Macros.Linux.MET_PPI
+++ b/apps/common/modified_src/cice5.1.2/bld/Macros.Linux.MET_PPI
@@ -41,7 +41,7 @@ endif
 ifeq ($(IO_TYPE), netcdf)
    CPPDEFS :=  $(CPPDEFS) -Dncdf
    INCLDIR :=  $(INCLDIR) -I/modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-ucx1.17-i22-2024-prod/include -I/modules/rhel8/user-apps/openmpi/5.0.5-IB-ucx1.17-i22-2024/include 
-   SLIBS   :=  $(SLIBS) -L/modules/rhel8/user-apps/openmpi/5.0.5-IB-ucx1.17-i22-2024/lib -L/modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-ucx1.17-i22-2024-prod/lib -lnetcdff -lnetcdf -L/modules/rhel8/Compiler/HPC-Toolkit/2022/2022.3.1.16997/compiler/latest/linux/compiler/lib -L/modules/rhel8/user-apps/netcdf/nnetcdf-4.6.1-IB-ucx1.17-i22-2024-prod/lib -lhdf5_hl -lhdf5 -lsz -lz -lm
+   SLIBS   :=  $(SLIBS) -L/modules/rhel8/user-apps/openmpi/5.0.5-IB-ucx1.17-i22-2024/lib -L/modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-ucx1.17-i22-2024-prod/lib -lnetcdff -lnetcdf -L/modules/rhel8/Compiler/HPC-Toolkit/2022/2022.3.1.16997/compiler/latest/linux/compiler/lib -L/modules/rhel8/user-apps/netcdf/netcdf-4.6.1-IB-ucx1.17-i22-2024-prod/lib -lhdf5_hl -lhdf5 -lsz -lz -lm
 endif
 
 ifeq ($(compile_threaded), true) 

--- a/apps/modules.sh
+++ b/apps/modules.sh
@@ -37,6 +37,14 @@ elif [ "$METROMS_MYHOST" == "met_ppi" ]; then
       module add IB-R8-B/netcdf/4.6.1-IB-i22-2024
       module add IB-R8-B/openmpi/5.0.5-IB-i22-2024
       echo "Modules for" $METROMS_LOGINNODE "loaded"
+    elif [ "$METROMS_LOGINNODE" == "r8_b_ucx" ]; then
+      # add modules for IB B
+      module use /modules/MET/rhel8/user-modules/ /modules/MET/rhel8/IT-modules
+      module add compiler/Intel2022
+      module add IB-R8-A/UCX1.17/netcdf/4.6.1-IB-ucx1.17-i22-2024
+      module add IB-R8-A/UCX1.17/openmpi/5.0.5-IB-ucx1.17-i22-2024
+      echo "Modules for" $METROMS_LOGINNODE "loaded"
+    module list
     fi
   else
     echo "Undefined linux distro for met_ppi"

--- a/apps/myenv.bash
+++ b/apps/myenv.bash
@@ -32,6 +32,10 @@ if [ "$METROMS_MYHOST" == "met_ppi" ]; then
         export METROMS_TMPDIR=$HOME/run
         export METROMS_BLDDIR=$HOME/work/sea/ROMS/metroms
         export METROMS_APPDIR=$HOME/sea/ROMS/metroms_apps
+        echo "METROMS_BASEDIR: $METROMS_BASEDIR"
+        echo "METROMS_TMPDIR: $METROMS_TMPDIR"
+        echo "METROMS_BLDDIR: $METROMS_BLDDIR"
+        echo "METROMS_APPDIR: $METROMS_APPDIR"
     else
     	export METROMS_BASEDIR=$HOME/metroms
     if [ -d "/lustre/storeB/users/$USER" ]; then


### PR DESCRIPTION
- Added modules when running on IB B ucx queue on PPI:
      module use /modules/MET/rhel8/user-modules/ /modules/MET/rhel8/IT-modules
      module add compiler/Intel2022
      module add IB-R8-A/UCX1.17/netcdf/4.6.1-IB-ucx1.17-i22-2024
      module add IB-R8-A/UCX1.17/openmpi/5.0.5-IB-ucx1.17-i22-2024
- Fixed typo in CICE macro file: Macros.Linux.MET_PPI